### PR TITLE
method(d,n,i) fix for missing properties

### DIFF
--- a/src/selection/index.ts
+++ b/src/selection/index.ts
@@ -24,7 +24,7 @@ import {
   specularTexture,
 } from './property/material';
 import { registerInstancedBuffer, setInstancedBuffer } from './property/instancedBuffer';
-import { attr, props, prop } from './property/attr';
+import { attr, props, prop } from './property/prop';
 import { run } from './utility/run';
 import { dispose } from './bind/dispose';
 import { drawTextDT, scaleDT } from './property/dynamicTexture';

--- a/src/selection/property/prop.ts
+++ b/src/selection/property/prop.ts
@@ -36,7 +36,7 @@ export function attr(this: Selection, accessor: string, value: any) {
 export function prop(this: Selection, accessor: string, value: any) {
   this.selected.forEach((node, i) => {
     hasIn(node, accessor)
-      ? set(node, accessor, value instanceof Function ? value(node.metadata.data, node, i) : value)
+      ? set(node, accessor, value instanceof Function ? value(node.metadata.data ??= {}, node, i) : value)
       : console.error(accessor + ' not a property of ' + node);
   });
   return this;
@@ -57,7 +57,7 @@ export function props(this: Selection, properties: {}) {
             node,
             accessor,
             (properties as any)[accessor] instanceof Function
-              ? (properties as any)[accessor](node.metadata.data, node, i)
+              ? (properties as any)[accessor](node.metadata.data ??= {}, node, i)
               : (properties as any)[accessor],
           )
         : console.log(accessor + ' not property of ' + node);

--- a/src/selection/utility/filter.ts
+++ b/src/selection/utility/filter.ts
@@ -10,10 +10,10 @@ import { Selection } from '../index';
  * @param method A function with two parameters d (the binded data) and i (the index) that returns a boolean.
  * @returns The modified selection
  */
-export function filter(this: Selection, method: (d: any, i: number) => boolean) {
+export function filter(this: Selection, method: (d: any, n: Node, i: number) => boolean) {
   let filtered: Node[] = [];
   this.selected.forEach((node, i) => {
-    if (method(node.metadata.data, i)) filtered.push(node);
+    if (method(node.metadata.data ??= {}, node, i)) filtered.push(node);
   });
 
   return new Selection(filtered, this.scene);

--- a/src/selection/utility/run.ts
+++ b/src/selection/utility/run.ts
@@ -7,7 +7,7 @@ import { Selection } from '../index';
 export function run(this: Selection, method: (d: any, node: Node, i: number) => any) {
   let values: Object[] = [];
   this.selected.forEach((node, i) => {
-    method(node.metadata.data, node, i)
+    method(node.metadata.data ??= {}, node, i)
   });
   return this;
 }


### PR DESCRIPTION
Allow methods prop, filter, and run to sill work when node has no metadata.data property