### PR TITLE
Transitions

### DIFF
--- a/anu-examples/examples/Animation/animate.js
+++ b/anu-examples/examples/Animation/animate.js
@@ -17,11 +17,13 @@ export const animate = function(engine){
   const camera = new ArcRotateCamera("Camera", -(Math.PI / 4) * 3, Math.PI / 4, 10, new Vector3(0, 0, 0), scene);
   camera.attachControl(true)
 
-  let box = anu.create('box', 'ourBox', {}, [{}]);
+  //let box = anu.create('box', 'ourBox', {}, [{}]);
+
 
   let nodes = anu.bind("box", [...new Array(1)])
 
   //let boxSelection = new anu.Selection(nodes.selected, scene, new Animatable(scene, box))
+
 
   nodes
     .material(() => new StandardMaterial('mat'))
@@ -31,13 +33,15 @@ export const animate = function(engine){
 
       return (t) => {
         let rgb = color(inter(t)).rgb();
-        console.log(rgb)
         n.material.diffuseColor = new Color3(rgb.r / 255, rgb.g /255, rgb.b /255);
       }
       
     })
     
-        
+
+
+
+
 
 //let animate = Animation.CreateAndStartAnimation("boxscale", box, "scaling.x", 1, 1, 1.0, 1.5, 0);
 //let animate2 = Animation.CreateAndStartAnimation("boxscale", box, "scaling.y", 1, 1, 1.0, 1.5, 0);

--- a/anu-examples/examples/Animation/animate.js
+++ b/anu-examples/examples/Animation/animate.js
@@ -2,8 +2,8 @@
 // Copyright : J.P. Morgan Chase & Co.
 
 import * as anu from '@jpmorganchase/anu' //import anu, this project is using a local import of babylon js located at ../babylonjs-anu this may not be the latest version and is used for simplicity.
-import { Scene, HemisphericLight, ArcRotateCamera, Vector3, Animation, Animatable, CircleEase, BounceEase} from "@babylonjs/core";
-import { interpolate } from 'd3';
+import { Scene, HemisphericLight, ArcRotateCamera, Vector3, Animation, Animatable, CircleEase, BounceEase, StandardMaterial, Color3} from "@babylonjs/core";
+import { interpolate, interpolateBrBG, color} from 'd3';
 
 //create and export a function that takes a babylon engine and returns a scene
 export const animate = function(engine){
@@ -19,20 +19,24 @@ export const animate = function(engine){
 
   let box = anu.create('box', 'ourBox', {}, [{}]);
 
-  let nodes = anu.bindInstance(box, [...new Array(1)])
+  let nodes = anu.bind("box", [...new Array(1)])
 
   //let boxSelection = new anu.Selection(nodes.selected, scene, new Animatable(scene, box))
 
-  nodes.transition((d,n,i) => ({duration: 250, loopMode: 0, delay: 2000,  easingFunction: new CircleEase()}))
-              .tween((d,n,i) => { 
-                let inter = interpolate(0, 10);
+  nodes
+    .material(() => new StandardMaterial('mat'))
+    .transition((d,n,i) => ({duration: 1000, loopMode: 0, delay: 0,  easingFunction: new CircleEase(), onAnimationEnd: () =>  { console.log('hi') } }))
+    .tween((d,n,i) => { 
+      let inter = interpolateBrBG
 
-                return (t) => {
-                 n.position.x = inter(t);
-                }
-                
-              })
-             
+      return (t) => {
+        let rgb = color(inter(t)).rgb();
+        console.log(rgb)
+        n.material.diffuseColor = new Color3(rgb.r / 255, rgb.g /255, rgb.b /255);
+      }
+      
+    })
+    
         
 
 //let animate = Animation.CreateAndStartAnimation("boxscale", box, "scaling.x", 1, 1, 1.0, 1.5, 0);

--- a/anu-examples/examples/Animation/animate.js
+++ b/anu-examples/examples/Animation/animate.js
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright : J.P. Morgan Chase & Co.
+
+import * as anu from '@jpmorganchase/anu' //import anu, this project is using a local import of babylon js located at ../babylonjs-anu this may not be the latest version and is used for simplicity.
+import { Scene, HemisphericLight, ArcRotateCamera, Vector3, Animation, Animatable} from "@babylonjs/core";
+
+//create and export a function that takes a babylon engine and returns a scene
+export const animate = function(engine){
+    
+  const scene = new Scene(engine)
+
+  console.log(scene.getEngine().constructor.LastCreatedScene)
+
+  new HemisphericLight('light1', new Vector3(0, 10, 0), scene)
+
+  const camera = new ArcRotateCamera("Camera", -(Math.PI / 4) * 3, Math.PI / 4, 10, new Vector3(0, 0, 0), scene);
+  camera.attachControl(true)
+
+  let box = anu.create('box', 'ourBox', {}, [{}]);
+
+  let nodes = anu.bindInstance(box, [...new Array(10)])
+
+  let boxSelection = new anu.Selection(nodes.selected, scene, new Animatable(scene, box))
+
+  boxSelection.positionX((d,n,i) => i)
+
+//let animate = Animation.CreateAndStartAnimation("boxscale", box, "scaling.x", 1, 1, 1.0, 1.5, 0);
+//let animate2 = Animation.CreateAndStartAnimation("boxscale", box, "scaling.y", 1, 1, 1.0, 1.5, 0);
+
+  return scene;
+}; 

--- a/anu-examples/examples/Animation/animate.js
+++ b/anu-examples/examples/Animation/animate.js
@@ -3,6 +3,7 @@
 
 import * as anu from '@jpmorganchase/anu' //import anu, this project is using a local import of babylon js located at ../babylonjs-anu this may not be the latest version and is used for simplicity.
 import { Scene, HemisphericLight, ArcRotateCamera, Vector3, Animation, Animatable, CircleEase, BounceEase} from "@babylonjs/core";
+import { interpolate } from 'd3';
 
 //create and export a function that takes a babylon engine and returns a scene
 export const animate = function(engine){
@@ -22,14 +23,15 @@ export const animate = function(engine){
 
   //let boxSelection = new anu.Selection(nodes.selected, scene, new Animatable(scene, box))
 
-  nodes.transition((d,n,i) => ({duration: 1000, loopMode: 0, delay: 2000,  easingFunction: new CircleEase()}))
-              .positionX((d,n,i) => i + 10)
-              .transition()
-              .positionY((d, n, i) => i + 10)
-              .transition()
-              .positionZ((d, n, i) => i + 10)
-              .transition({sequence: false})
-              .scaling((d, n, i) => new Vector3(4,4,4))
+  nodes.transition((d,n,i) => ({duration: 250, loopMode: 0, delay: 2000,  easingFunction: new CircleEase()}))
+              .tween((d,n,i) => { 
+                let inter = interpolate(0, 10);
+
+                return (t) => {
+                 n.position.x = inter(t);
+                }
+                
+              })
              
         
 

--- a/anu-examples/examples/Animation/animate.js
+++ b/anu-examples/examples/Animation/animate.js
@@ -2,7 +2,7 @@
 // Copyright : J.P. Morgan Chase & Co.
 
 import * as anu from '@jpmorganchase/anu' //import anu, this project is using a local import of babylon js located at ../babylonjs-anu this may not be the latest version and is used for simplicity.
-import { Scene, HemisphericLight, ArcRotateCamera, Vector3, Animation, Animatable} from "@babylonjs/core";
+import { Scene, HemisphericLight, ArcRotateCamera, Vector3, Animation, Animatable, CircleEase, BounceEase} from "@babylonjs/core";
 
 //create and export a function that takes a babylon engine and returns a scene
 export const animate = function(engine){
@@ -22,8 +22,12 @@ export const animate = function(engine){
 
   //let boxSelection = new anu.Selection(nodes.selected, scene, new Animatable(scene, box))
 
-  nodes.transition({duration: 10})
-              .positionX((d,n,i) => i + 1)
+  nodes.transition((d,n,i) => ({duration: 1000, delay: 500, loopMode: 0,  easingFunction: new CircleEase()}))
+              .positionX((d,n,i) => i + 10)
+              .transition()
+              .positionY((d,n,i) => i + 8)
+              
+  console.log(nodes.selected[0].metadata.promise);
 
 //let animate = Animation.CreateAndStartAnimation("boxscale", box, "scaling.x", 1, 1, 1.0, 1.5, 0);
 //let animate2 = Animation.CreateAndStartAnimation("boxscale", box, "scaling.y", 1, 1, 1.0, 1.5, 0);

--- a/anu-examples/examples/Animation/animate.js
+++ b/anu-examples/examples/Animation/animate.js
@@ -22,12 +22,14 @@ export const animate = function(engine){
 
   //let boxSelection = new anu.Selection(nodes.selected, scene, new Animatable(scene, box))
 
-  nodes.transition((d,n,i) => ({duration: 5000, loopMode: 0,  easingFunction: new CircleEase()}))
+  nodes.transition((d,n,i) => ({duration: 1000, loopMode: 0, delay: 2000,  easingFunction: new CircleEase()}))
               .positionX((d,n,i) => i + 10)
               .transition()
               .positionY((d, n, i) => i + 10)
               .transition()
               .positionZ((d, n, i) => i + 10)
+              .transition({sequence: false})
+              .scaling((d, n, i) => new Vector3(4,4,4))
              
         
 

--- a/anu-examples/examples/Animation/animate.js
+++ b/anu-examples/examples/Animation/animate.js
@@ -22,12 +22,14 @@ export const animate = function(engine){
 
   //let boxSelection = new anu.Selection(nodes.selected, scene, new Animatable(scene, box))
 
-  nodes.transition((d,n,i) => ({duration: 1000, delay: 500, loopMode: 0,  easingFunction: new CircleEase()}))
+  nodes.transition((d,n,i) => ({duration: 5000, loopMode: 0,  easingFunction: new CircleEase()}))
               .positionX((d,n,i) => i + 10)
               .transition()
-              .positionY((d,n,i) => i + 8)
-              
-  console.log(nodes.selected[0].metadata.promise);
+              .positionY((d, n, i) => i + 10)
+              .transition()
+              .positionZ((d, n, i) => i + 10)
+             
+        
 
 //let animate = Animation.CreateAndStartAnimation("boxscale", box, "scaling.x", 1, 1, 1.0, 1.5, 0);
 //let animate2 = Animation.CreateAndStartAnimation("boxscale", box, "scaling.y", 1, 1, 1.0, 1.5, 0);

--- a/anu-examples/examples/Animation/animate.js
+++ b/anu-examples/examples/Animation/animate.js
@@ -18,11 +18,12 @@ export const animate = function(engine){
 
   let box = anu.create('box', 'ourBox', {}, [{}]);
 
-  let nodes = anu.bindInstance(box, [...new Array(10)])
+  let nodes = anu.bindInstance(box, [...new Array(1)])
 
-  let boxSelection = new anu.Selection(nodes.selected, scene, new Animatable(scene, box))
+  //let boxSelection = new anu.Selection(nodes.selected, scene, new Animatable(scene, box))
 
-  boxSelection.positionX((d,n,i) => i)
+  nodes.transition({duration: 10})
+              .positionX((d,n,i) => i + 1)
 
 //let animate = Animation.CreateAndStartAnimation("boxscale", box, "scaling.x", 1, 1, 1.0, 1.5, 0);
 //let animate2 = Animation.CreateAndStartAnimation("boxscale", box, "scaling.y", 1, 1, 1.0, 1.5, 0);

--- a/anu-examples/main.js
+++ b/anu-examples/main.js
@@ -49,6 +49,7 @@ import { benchmark } from './examples/Benchmarks/benchmark';
 import { fig1 } from './examples/Figures/fig1';
 import { fig2 } from './examples/Figures/fig2';
 import { scatterplotThinInstance } from './examples/ScatterPlots/ScatterplotThinInstance';
+import { animate } from './examples/Animation/animate';
 
 
 const queryString = window.location.search;
@@ -107,6 +108,7 @@ const scenes = {
   'fig1': fig1,
   'fig2': fig2,
   'scatterplotThinInstance': scatterplotThinInstance,
+  'animate': animate
 }
 
 let scene = scenes[urlParams.get('example')](babylonEngine);

--- a/anu-examples/package.json
+++ b/anu-examples/package.json
@@ -22,3 +22,4 @@
     "topojson-simplify": "^3.0.3"
   }
 }
+

--- a/docs/api/classes/Axis.md
+++ b/docs/api/classes/Axis.md
@@ -2,6 +2,12 @@
 
 # Class: Axis
 
+## Hierarchy
+
+- `TransformNode`
+
+  ↳ **`Axis`**
+
 ## Table of contents
 
 ### Constructors
@@ -11,23 +17,191 @@
 ### Properties
 
 - [CoT](Axis.md#cot)
+- [\_accessibilityTag](Axis.md#_accessibilitytag)
+- [\_cache](Axis.md#_cache)
+- [\_childUpdateId](Axis.md#_childupdateid)
+- [\_children](Axis.md#_children)
+- [\_currentRenderId](Axis.md#_currentrenderid)
+- [\_disposePhysicsObserver](Axis.md#_disposephysicsobserver)
+- [\_indexInSceneTransformNodesArray](Axis.md#_indexinscenetransformnodesarray)
+- [\_internalMetadata](Axis.md#_internalmetadata)
+- [\_isDirty](Axis.md#_isdirty)
+- [\_isNode](Axis.md#_isnode)
+- [\_isWorldMatrixFrozen](Axis.md#_isworldmatrixfrozen)
+- [\_localMatrix](Axis.md#_localmatrix)
+- [\_parentContainer](Axis.md#_parentcontainer)
+- [\_parentNode](Axis.md#_parentnode)
+- [\_physicsBody](Axis.md#_physicsbody)
+- [\_poseMatrix](Axis.md#_posematrix)
+- [\_postMultiplyPivotMatrix](Axis.md#_postmultiplypivotmatrix)
+- [\_ranges](Axis.md#_ranges)
+- [\_scaling](Axis.md#_scaling)
+- [\_scene](Axis.md#_scene)
+- [\_waitingParentId](Axis.md#_waitingparentid)
+- [\_waitingParentInstanceIndex](Axis.md#_waitingparentinstanceindex)
+- [\_waitingParsedUniqueId](Axis.md#_waitingparseduniqueid)
+- [\_worldMatrix](Axis.md#_worldmatrix)
+- [\_worldMatrixDeterminant](Axis.md#_worldmatrixdeterminant)
+- [\_worldMatrixDeterminantIsDirty](Axis.md#_worldmatrixdeterminantisdirty)
+- [animations](Axis.md#animations)
 - [background](Axis.md#background)
 - [domain](Axis.md#domain)
 - [grid](Axis.md#grid)
+- [id](Axis.md#id)
+- [ignoreNonUniformScaling](Axis.md#ignorenonuniformscaling)
+- [inspectableCustomProperties](Axis.md#inspectablecustomproperties)
 - [label](Axis.md#label)
+- [metadata](Axis.md#metadata)
 - [name](Axis.md#name)
+- [onAccessibilityTagChangedObservable](Axis.md#onaccessibilitytagchangedobservable)
+- [onAfterWorldMatrixUpdateObservable](Axis.md#onafterworldmatrixupdateobservable)
+- [onDisposeObservable](Axis.md#ondisposeobservable)
+- [onReady](Axis.md#onready)
 - [options](Axis.md#options)
+- [physicsBody](Axis.md#physicsbody)
+- [reIntegrateRotationIntoRotationQuaternion](Axis.md#reintegraterotationintorotationquaternion)
+- [reservedDataStore](Axis.md#reserveddatastore)
 - [scales](Axis.md#scales)
-- [scene](Axis.md#scene)
+- [scalingDeterminant](Axis.md#scalingdeterminant)
 - [setBackground](Axis.md#setbackground)
 - [setDomain](Axis.md#setdomain)
 - [setGrid](Axis.md#setgrid)
 - [setLabel](Axis.md#setlabel)
+- [state](Axis.md#state)
+- [uniqueId](Axis.md#uniqueid)
+- [BILLBOARDMODE\_ALL](Axis.md#billboardmode_all)
+- [BILLBOARDMODE\_NONE](Axis.md#billboardmode_none)
+- [BILLBOARDMODE\_USE\_POSITION](Axis.md#billboardmode_use_position)
+- [BILLBOARDMODE\_X](Axis.md#billboardmode_x)
+- [BILLBOARDMODE\_Y](Axis.md#billboardmode_y)
+- [BILLBOARDMODE\_Z](Axis.md#billboardmode_z)
+- [BillboardUseParentOrientation](Axis.md#billboarduseparentorientation)
+- [\_AnimationRangeFactory](Axis.md#_animationrangefactory)
+
+### Accessors
+
+- [absolutePosition](Axis.md#absoluteposition)
+- [absoluteRotationQuaternion](Axis.md#absoluterotationquaternion)
+- [absoluteScaling](Axis.md#absolutescaling)
+- [accessibilityTag](Axis.md#accessibilitytag)
+- [animationPropertiesOverride](Axis.md#animationpropertiesoverride)
+- [behaviors](Axis.md#behaviors)
+- [billboardMode](Axis.md#billboardmode)
+- [doNotSerialize](Axis.md#donotserialize)
+- [forward](Axis.md#forward)
+- [infiniteDistance](Axis.md#infinitedistance)
+- [isWorldMatrixFrozen](Axis.md#isworldmatrixfrozen)
+- [nonUniformScaling](Axis.md#nonuniformscaling)
+- [onClonedObservable](Axis.md#onclonedobservable)
+- [onDispose](Axis.md#ondispose)
+- [onEnabledStateChangedObservable](Axis.md#onenabledstatechangedobservable)
+- [parent](Axis.md#parent)
+- [position](Axis.md#position)
+- [preserveParentRotationForBillboard](Axis.md#preserveparentrotationforbillboard)
+- [right](Axis.md#right)
+- [rotation](Axis.md#rotation)
+- [rotationQuaternion](Axis.md#rotationquaternion)
+- [scaling](Axis.md#scaling)
+- [up](Axis.md#up)
+- [worldMatrixFromCache](Axis.md#worldmatrixfromcache)
 
 ### Methods
 
-- [setCoT](Axis.md#setcot)
+- [\_addToSceneRootNodes](Axis.md#_addtoscenerootnodes)
+- [\_afterComputeWorldMatrix](Axis.md#_aftercomputeworldmatrix)
+- [\_getActionManagerForTrigger](Axis.md#_getactionmanagerfortrigger)
+- [\_getDescendants](Axis.md#_getdescendants)
+- [\_getEffectiveParent](Axis.md#_geteffectiveparent)
+- [\_getWorldMatrixDeterminant](Axis.md#_getworldmatrixdeterminant)
+- [\_initCache](Axis.md#_initcache)
+- [\_isSynchronized](Axis.md#_issynchronized)
+- [\_markSyncedWithParent](Axis.md#_marksyncedwithparent)
+- [\_removeFromSceneRootNodes](Axis.md#_removefromscenerootnodes)
+- [\_serializeAsParent](Axis.md#_serializeasparent)
+- [\_setReady](Axis.md#_setready)
+- [\_syncParentEnabledState](Axis.md#_syncparentenabledstate)
+- [\_updateCache](Axis.md#_updatecache)
+- [\_updateNonUniformScalingState](Axis.md#_updatenonuniformscalingstate)
+- [addBehavior](Axis.md#addbehavior)
+- [addChild](Axis.md#addchild)
+- [addRotation](Axis.md#addrotation)
+- [applyAngularImpulse](Axis.md#applyangularimpulse)
+- [applyImpulse](Axis.md#applyimpulse)
+- [attachToBone](Axis.md#attachtobone)
+- [beginAnimation](Axis.md#beginanimation)
+- [clone](Axis.md#clone)
+- [computeWorldMatrix](Axis.md#computeworldmatrix)
+- [createAnimationRange](Axis.md#createanimationrange)
+- [deleteAnimationRange](Axis.md#deleteanimationrange)
+- [detachFromBone](Axis.md#detachfrombone)
+- [dispose](Axis.md#dispose)
+- [freezeWorldMatrix](Axis.md#freezeworldmatrix)
+- [getAbsolutePivotPoint](Axis.md#getabsolutepivotpoint)
+- [getAbsolutePivotPointToRef](Axis.md#getabsolutepivotpointtoref)
+- [getAbsolutePosition](Axis.md#getabsoluteposition)
+- [getAnimationByName](Axis.md#getanimationbyname)
+- [getAnimationRange](Axis.md#getanimationrange)
+- [getAnimationRanges](Axis.md#getanimationranges)
+- [getBehaviorByName](Axis.md#getbehaviorbyname)
+- [getChildMeshes](Axis.md#getchildmeshes)
+- [getChildTransformNodes](Axis.md#getchildtransformnodes)
+- [getChildren](Axis.md#getchildren)
+- [getClassName](Axis.md#getclassname)
+- [getDescendants](Axis.md#getdescendants)
+- [getDirection](Axis.md#getdirection)
+- [getDirectionToRef](Axis.md#getdirectiontoref)
+- [getDistanceToCamera](Axis.md#getdistancetocamera)
+- [getEngine](Axis.md#getengine)
+- [getHierarchyBoundingVectors](Axis.md#gethierarchyboundingvectors)
+- [getPhysicsBody](Axis.md#getphysicsbody)
+- [getPivotMatrix](Axis.md#getpivotmatrix)
+- [getPivotPoint](Axis.md#getpivotpoint)
+- [getPivotPointToRef](Axis.md#getpivotpointtoref)
+- [getPoseMatrix](Axis.md#getposematrix)
+- [getPositionExpressedInLocalSpace](Axis.md#getpositionexpressedinlocalspace)
+- [getPositionInCameraSpace](Axis.md#getpositionincameraspace)
+- [getScene](Axis.md#getscene)
+- [getWorldMatrix](Axis.md#getworldmatrix)
+- [instantiateHierarchy](Axis.md#instantiatehierarchy)
+- [isDescendantOf](Axis.md#isdescendantof)
+- [isDisposed](Axis.md#isdisposed)
+- [isEnabled](Axis.md#isenabled)
+- [isReady](Axis.md#isready)
+- [isSynchronized](Axis.md#issynchronized)
+- [isSynchronizedWithParent](Axis.md#issynchronizedwithparent)
+- [isUsingPivotMatrix](Axis.md#isusingpivotmatrix)
+- [isUsingPostMultiplyPivotMatrix](Axis.md#isusingpostmultiplypivotmatrix)
+- [isWorldMatrixCameraDependent](Axis.md#isworldmatrixcameradependent)
+- [locallyTranslate](Axis.md#locallytranslate)
+- [lookAt](Axis.md#lookat)
+- [markAsDirty](Axis.md#markasdirty)
+- [normalizeToUnitCube](Axis.md#normalizetounitcube)
+- [registerAfterWorldMatrixUpdate](Axis.md#registerafterworldmatrixupdate)
+- [removeBehavior](Axis.md#removebehavior)
+- [removeChild](Axis.md#removechild)
+- [resetLocalMatrix](Axis.md#resetlocalmatrix)
+- [rotate](Axis.md#rotate)
+- [rotateAround](Axis.md#rotatearound)
+- [serialize](Axis.md#serialize)
+- [serializeAnimationRanges](Axis.md#serializeanimationranges)
+- [setAbsolutePosition](Axis.md#setabsoluteposition)
+- [setDirection](Axis.md#setdirection)
+- [setEnabled](Axis.md#setenabled)
+- [setParent](Axis.md#setparent)
+- [setPivotMatrix](Axis.md#setpivotmatrix)
+- [setPivotPoint](Axis.md#setpivotpoint)
+- [setPositionWithLocalVector](Axis.md#setpositionwithlocalvector)
+- [setPreTransformMatrix](Axis.md#setpretransformmatrix)
 - [setScales](Axis.md#setscales)
+- [translate](Axis.md#translate)
+- [unfreezeWorldMatrix](Axis.md#unfreezeworldmatrix)
+- [unregisterAfterWorldMatrixUpdate](Axis.md#unregisterafterworldmatrixupdate)
+- [updateCache](Axis.md#updatecache)
+- [updatePoseMatrix](Axis.md#updateposematrix)
+- [AddNodeConstructor](Axis.md#addnodeconstructor)
+- [Construct](Axis.md#construct)
+- [Parse](Axis.md#parse)
+- [ParseAnimationRanges](Axis.md#parseanimationranges)
 
 ## Constructors
 
@@ -47,9 +221,13 @@
 
 [`Axis`](Axis.md)
 
+#### Overrides
+
+TransformNode.constructor
+
 #### Defined in
 
-[prefabs/Axis/Axis.ts:48](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Axis/Axis.ts#L48)
+[src/prefabs/Axis/Axis.ts:46](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Axis/Axis.ts#L46)
 
 ## Properties
 
@@ -59,7 +237,391 @@
 
 #### Defined in
 
-[prefabs/Axis/Axis.ts:41](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Axis/Axis.ts#L41)
+[src/prefabs/Axis/Axis.ts:39](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Axis/Axis.ts#L39)
+
+___
+
+### \_accessibilityTag
+
+• `Protected` **\_accessibilityTag**: `IAccessibilityTag`
+
+#### Inherited from
+
+TransformNode.\_accessibilityTag
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:82
+
+___
+
+### \_cache
+
+• **\_cache**: `any`
+
+#### Inherited from
+
+TransformNode.\_cache
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:119
+
+___
+
+### \_childUpdateId
+
+• **\_childUpdateId**: `number`
+
+#### Inherited from
+
+TransformNode.\_childUpdateId
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:109
+
+___
+
+### \_children
+
+• `Protected` **\_children**: `Node`[]
+
+#### Inherited from
+
+TransformNode.\_children
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:122
+
+___
+
+### \_currentRenderId
+
+• **\_currentRenderId**: `number`
+
+#### Inherited from
+
+TransformNode.\_currentRenderId
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:106
+
+___
+
+### \_disposePhysicsObserver
+
+• **\_disposePhysicsObserver**: `Observer`\<`Node`\>
+
+#### Inherited from
+
+TransformNode.\_disposePhysicsObserver
+
+#### Defined in
+
+node_modules/@babylonjs/core/Physics/v2/physicsEngineComponent.d.ts:35
+
+___
+
+### \_indexInSceneTransformNodesArray
+
+• **\_indexInSceneTransformNodesArray**: `number`
+
+#### Inherited from
+
+TransformNode.\_indexInSceneTransformNodesArray
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:112
+
+___
+
+### \_internalMetadata
+
+• **\_internalMetadata**: `any`
+
+#### Inherited from
+
+TransformNode.\_internalMetadata
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:67
+
+___
+
+### \_isDirty
+
+• `Protected` **\_isDirty**: `boolean`
+
+#### Inherited from
+
+TransformNode.\_isDirty
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:24
+
+___
+
+### \_isNode
+
+• `Readonly` **\_isNode**: ``true``
+
+#### Inherited from
+
+TransformNode.\_isNode
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:160
+
+___
+
+### \_isWorldMatrixFrozen
+
+• `Protected` **\_isWorldMatrixFrozen**: `boolean`
+
+#### Inherited from
+
+TransformNode.\_isWorldMatrixFrozen
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:110
+
+___
+
+### \_localMatrix
+
+• **\_localMatrix**: `Matrix`
+
+#### Inherited from
+
+TransformNode.\_localMatrix
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:101
+
+___
+
+### \_parentContainer
+
+• **\_parentContainer**: `AbstractScene`
+
+#### Inherited from
+
+TransformNode.\_parentContainer
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:93
+
+___
+
+### \_parentNode
+
+• `Protected` **\_parentNode**: `Node`
+
+#### Inherited from
+
+TransformNode.\_parentNode
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:120
+
+___
+
+### \_physicsBody
+
+• **\_physicsBody**: `PhysicsBody`
+
+#### Inherited from
+
+TransformNode.\_physicsBody
+
+#### Defined in
+
+node_modules/@babylonjs/core/Physics/v2/physicsEngineComponent.d.ts:14
+
+___
+
+### \_poseMatrix
+
+• **\_poseMatrix**: `Matrix`
+
+#### Inherited from
+
+TransformNode.\_poseMatrix
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:99
+
+___
+
+### \_postMultiplyPivotMatrix
+
+• **\_postMultiplyPivotMatrix**: `boolean`
+
+#### Inherited from
+
+TransformNode.\_postMultiplyPivotMatrix
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:109
+
+___
+
+### \_ranges
+
+• `Protected` **\_ranges**: `Object`
+
+#### Index signature
+
+▪ [name: `string`]: `Nullable`\<`AnimationRange`\>
+
+#### Inherited from
+
+TransformNode.\_ranges
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:98
+
+___
+
+### \_scaling
+
+• `Protected` **\_scaling**: `Vector3`
+
+#### Inherited from
+
+TransformNode.\_scaling
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:52
+
+___
+
+### \_scene
+
+• **\_scene**: `Scene`
+
+#### Inherited from
+
+TransformNode.\_scene
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:117
+
+___
+
+### \_waitingParentId
+
+• **\_waitingParentId**: `string`
+
+#### Inherited from
+
+TransformNode.\_waitingParentId
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:111
+
+___
+
+### \_waitingParentInstanceIndex
+
+• **\_waitingParentInstanceIndex**: `string`
+
+#### Inherited from
+
+TransformNode.\_waitingParentInstanceIndex
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:113
+
+___
+
+### \_waitingParsedUniqueId
+
+• **\_waitingParsedUniqueId**: `number`
+
+#### Inherited from
+
+TransformNode.\_waitingParsedUniqueId
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:115
+
+___
+
+### \_worldMatrix
+
+• **\_worldMatrix**: `Matrix`
+
+#### Inherited from
+
+TransformNode.\_worldMatrix
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:124
+
+___
+
+### \_worldMatrixDeterminant
+
+• **\_worldMatrixDeterminant**: `number`
+
+#### Inherited from
+
+TransformNode.\_worldMatrixDeterminant
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:126
+
+___
+
+### \_worldMatrixDeterminantIsDirty
+
+• **\_worldMatrixDeterminantIsDirty**: `boolean`
+
+#### Inherited from
+
+TransformNode.\_worldMatrixDeterminantIsDirty
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:128
+
+___
+
+### animations
+
+• **animations**: `Animation`[]
+
+Gets a list of Animations associated with the node
+
+#### Inherited from
+
+TransformNode.animations
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:97
 
 ___
 
@@ -77,7 +639,7 @@ ___
 
 #### Defined in
 
-[prefabs/Axis/Axis.ts:44](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Axis/Axis.ts#L44)
+[src/prefabs/Axis/Axis.ts:42](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Axis/Axis.ts#L42)
 
 ___
 
@@ -87,7 +649,7 @@ ___
 
 #### Defined in
 
-[prefabs/Axis/Axis.ts:43](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Axis/Axis.ts#L43)
+[src/prefabs/Axis/Axis.ts:41](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Axis/Axis.ts#L41)
 
 ___
 
@@ -97,7 +659,60 @@ ___
 
 #### Defined in
 
-[prefabs/Axis/Axis.ts:45](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Axis/Axis.ts#L45)
+[src/prefabs/Axis/Axis.ts:43](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Axis/Axis.ts#L43)
+
+___
+
+### id
+
+• **id**: `string`
+
+Gets or sets the id of the node
+
+#### Inherited from
+
+TransformNode.id
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:53
+
+___
+
+### ignoreNonUniformScaling
+
+• **ignoreNonUniformScaling**: `boolean`
+
+Gets or sets a boolean indicating that non uniform scaling (when at least one component is different from others) should be ignored.
+By default the system will update normals to compensate
+
+#### Inherited from
+
+TransformNode.ignoreNonUniformScaling
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:93
+
+___
+
+### inspectableCustomProperties
+
+• **inspectableCustomProperties**: `IInspectable`[]
+
+List of inspectable custom properties (used by the Inspector)
+
+**`See`**
+
+https://doc.babylonjs.com/toolsAndResources/inspector#extensibility
+
+#### Inherited from
+
+TransformNode.inspectableCustomProperties
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:76
 
 ___
 
@@ -115,7 +730,23 @@ ___
 
 #### Defined in
 
-[prefabs/Axis/Axis.ts:46](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Axis/Axis.ts#L46)
+[src/prefabs/Axis/Axis.ts:44](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Axis/Axis.ts#L44)
+
+___
+
+### metadata
+
+• **metadata**: `any`
+
+Gets or sets an object used to store user defined information for the node
+
+#### Inherited from
+
+TransformNode.metadata
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:65
 
 ___
 
@@ -123,9 +754,93 @@ ___
 
 • **name**: `string`
 
+Gets or sets the name of the node
+
+#### Inherited from
+
+TransformNode.name
+
 #### Defined in
 
-[prefabs/Axis/Axis.ts:38](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Axis/Axis.ts#L38)
+node_modules/@babylonjs/core/node.d.ts:49
+
+___
+
+### onAccessibilityTagChangedObservable
+
+• **onAccessibilityTagChangedObservable**: `Observable`\<`IAccessibilityTag`\>
+
+Observable fired when an accessibility tag is changed
+
+#### Inherited from
+
+TransformNode.onAccessibilityTagChangedObservable
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:86
+
+___
+
+### onAfterWorldMatrixUpdateObservable
+
+• **onAfterWorldMatrixUpdateObservable**: `Observable`\<`TransformNode`\>
+
+An event triggered after the world matrix is updated
+
+#### Inherited from
+
+TransformNode.onAfterWorldMatrixUpdateObservable
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:116
+
+___
+
+### onDisposeObservable
+
+• **onDisposeObservable**: `Observable`\<`Node`\>
+
+An event triggered when the mesh is disposed
+
+#### Inherited from
+
+TransformNode.onDisposeObservable
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:164
+
+___
+
+### onReady
+
+• **onReady**: (`node`: `Node`) => `void`
+
+Callback raised when the node is ready to be used
+
+#### Type declaration
+
+▸ (`node`): `void`
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `node` | `Node` |
+
+##### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.onReady
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:104
 
 ___
 
@@ -135,7 +850,55 @@ ___
 
 #### Defined in
 
-[prefabs/Axis/Axis.ts:39](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Axis/Axis.ts#L39)
+[src/prefabs/Axis/Axis.ts:38](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Axis/Axis.ts#L38)
+
+___
+
+### physicsBody
+
+• **physicsBody**: `PhysicsBody`
+
+**`See`**
+
+#### Inherited from
+
+TransformNode.physicsBody
+
+#### Defined in
+
+node_modules/@babylonjs/core/Physics/v2/physicsEngineComponent.d.ts:18
+
+___
+
+### reIntegrateRotationIntoRotationQuaternion
+
+• **reIntegrateRotationIntoRotationQuaternion**: `boolean`
+
+Gets or sets a boolean indicating that even if rotationQuaternion is defined, you can keep updating rotation property and Babylon.js will just mix both
+
+#### Inherited from
+
+TransformNode.reIntegrateRotationIntoRotationQuaternion
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:97
+
+___
+
+### reservedDataStore
+
+• **reservedDataStore**: `any`
+
+For internal use only. Please do not use.
+
+#### Inherited from
+
+TransformNode.reservedDataStore
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:71
 
 ___
 
@@ -145,17 +908,23 @@ ___
 
 #### Defined in
 
-[prefabs/Axis/Axis.ts:42](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Axis/Axis.ts#L42)
+[src/prefabs/Axis/Axis.ts:40](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Axis/Axis.ts#L40)
 
 ___
 
-### scene
+### scalingDeterminant
 
-• **scene**: `Scene`
+• **scalingDeterminant**: `number`
+
+Multiplication factor on scale x/y/z when computing the world matrix. Eg. for a 1x1x1 cube setting this to 2 will make it a 2x2x2 cube
+
+#### Inherited from
+
+TransformNode.scalingDeterminant
 
 #### Defined in
 
-[prefabs/Axis/Axis.ts:40](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Axis/Axis.ts#L40)
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:82
 
 ___
 
@@ -185,7 +954,7 @@ ___
 
 #### Defined in
 
-[prefabs/Axis/Axis.ts:120](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Axis/Axis.ts#L120)
+[src/prefabs/Axis/Axis.ts:119](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Axis/Axis.ts#L119)
 
 ___
 
@@ -209,7 +978,7 @@ ___
 
 #### Defined in
 
-[prefabs/Axis/Axis.ts:119](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Axis/Axis.ts#L119)
+[src/prefabs/Axis/Axis.ts:118](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Axis/Axis.ts#L118)
 
 ___
 
@@ -233,7 +1002,7 @@ ___
 
 #### Defined in
 
-[prefabs/Axis/Axis.ts:121](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Axis/Axis.ts#L121)
+[src/prefabs/Axis/Axis.ts:120](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Axis/Axis.ts#L120)
 
 ___
 
@@ -263,21 +1032,3226 @@ ___
 
 #### Defined in
 
-[prefabs/Axis/Axis.ts:122](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Axis/Axis.ts#L122)
+[src/prefabs/Axis/Axis.ts:121](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Axis/Axis.ts#L121)
 
-## Methods
+___
 
-### setCoT
+### state
 
-▸ **setCoT**(): [`Selection`](Selection.md)
+• **state**: `string`
 
-#### Returns
+Gets or sets a string used to store user defined state for the node
 
-[`Selection`](Selection.md)
+#### Inherited from
+
+TransformNode.state
 
 #### Defined in
 
-[prefabs/Axis/Axis.ts:60](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Axis/Axis.ts#L60)
+node_modules/@babylonjs/core/node.d.ts:61
+
+___
+
+### uniqueId
+
+• **uniqueId**: `number`
+
+Gets or sets the unique id of the node
+
+#### Inherited from
+
+TransformNode.uniqueId
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:57
+
+___
+
+### BILLBOARDMODE\_ALL
+
+▪ `Static` **BILLBOARDMODE\_ALL**: `number`
+
+Object will rotate to face the camera
+
+#### Inherited from
+
+TransformNode.BILLBOARDMODE\_ALL
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:34
+
+___
+
+### BILLBOARDMODE\_NONE
+
+▪ `Static` **BILLBOARDMODE\_NONE**: `number`
+
+Object will not rotate to face the camera
+
+#### Inherited from
+
+TransformNode.BILLBOARDMODE\_NONE
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:18
+
+___
+
+### BILLBOARDMODE\_USE\_POSITION
+
+▪ `Static` **BILLBOARDMODE\_USE\_POSITION**: `number`
+
+Object will rotate to face the camera's position instead of orientation
+
+#### Inherited from
+
+TransformNode.BILLBOARDMODE\_USE\_POSITION
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:38
+
+___
+
+### BILLBOARDMODE\_X
+
+▪ `Static` **BILLBOARDMODE\_X**: `number`
+
+Object will rotate to face the camera but only on the x axis
+
+#### Inherited from
+
+TransformNode.BILLBOARDMODE\_X
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:22
+
+___
+
+### BILLBOARDMODE\_Y
+
+▪ `Static` **BILLBOARDMODE\_Y**: `number`
+
+Object will rotate to face the camera but only on the y axis
+
+#### Inherited from
+
+TransformNode.BILLBOARDMODE\_Y
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:26
+
+___
+
+### BILLBOARDMODE\_Z
+
+▪ `Static` **BILLBOARDMODE\_Z**: `number`
+
+Object will rotate to face the camera but only on the z axis
+
+#### Inherited from
+
+TransformNode.BILLBOARDMODE\_Z
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:30
+
+___
+
+### BillboardUseParentOrientation
+
+▪ `Static` **BillboardUseParentOrientation**: `boolean`
+
+Child transform with Billboard flags should or should not apply parent rotation (default if off)
+
+#### Inherited from
+
+TransformNode.BillboardUseParentOrientation
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:42
+
+___
+
+### \_AnimationRangeFactory
+
+▪ `Static` **\_AnimationRangeFactory**: (`_name`: `string`, `_from`: `number`, `_to`: `number`) => `AnimationRange`
+
+#### Type declaration
+
+▸ (`_name`, `_from`, `_to`): `AnimationRange`
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `_name` | `string` |
+| `_from` | `number` |
+| `_to` | `number` |
+
+##### Returns
+
+`AnimationRange`
+
+#### Inherited from
+
+TransformNode.\_AnimationRangeFactory
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:28
+
+## Accessors
+
+### absolutePosition
+
+• `get` **absolutePosition**(): `Vector3`
+
+Returns the current mesh absolute position.
+Returns a Vector3.
+
+#### Returns
+
+`Vector3`
+
+#### Inherited from
+
+TransformNode.absolutePosition
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:185
+
+___
+
+### absoluteRotationQuaternion
+
+• `get` **absoluteRotationQuaternion**(): `Quaternion`
+
+Returns the current mesh absolute rotation.
+Returns a Quaternion.
+
+#### Returns
+
+`Quaternion`
+
+#### Inherited from
+
+TransformNode.absoluteRotationQuaternion
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:195
+
+___
+
+### absoluteScaling
+
+• `get` **absoluteScaling**(): `Vector3`
+
+Returns the current mesh absolute scaling.
+Returns a Vector3.
+
+#### Returns
+
+`Vector3`
+
+#### Inherited from
+
+TransformNode.absoluteScaling
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:190
+
+___
+
+### accessibilityTag
+
+• `get` **accessibilityTag**(): `IAccessibilityTag`
+
+#### Returns
+
+`IAccessibilityTag`
+
+#### Inherited from
+
+TransformNode.accessibilityTag
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:81
+
+• `set` **accessibilityTag**(`value`): `void`
+
+Gets or sets the accessibility tag to describe the node for accessibility purpose.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `value` | `IAccessibilityTag` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.accessibilityTag
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:80
+
+___
+
+### animationPropertiesOverride
+
+• `get` **animationPropertiesOverride**(): `AnimationPropertiesOverride`
+
+Gets or sets the animation properties override
+
+#### Returns
+
+`AnimationPropertiesOverride`
+
+#### Inherited from
+
+TransformNode.animationPropertiesOverride
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:152
+
+• `set` **animationPropertiesOverride**(`value`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `value` | `AnimationPropertiesOverride` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.animationPropertiesOverride
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:153
+
+___
+
+### behaviors
+
+• `get` **behaviors**(): `Behavior`\<`Node`\>[]
+
+Gets the list of attached behaviors
+
+#### Returns
+
+`Behavior`\<`Node`\>[]
+
+**`See`**
+
+https://doc.babylonjs.com/features/featuresDeepDive/behaviors
+
+#### Inherited from
+
+TransformNode.behaviors
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:215
+
+___
+
+### billboardMode
+
+• `get` **billboardMode**(): `number`
+
+Gets or sets the billboard mode. Default is 0.
+
+| Value | Type | Description |
+| --- | --- | --- |
+| 0 | BILLBOARDMODE_NONE |  |
+| 1 | BILLBOARDMODE_X |  |
+| 2 | BILLBOARDMODE_Y |  |
+| 4 | BILLBOARDMODE_Z |  |
+| 7 | BILLBOARDMODE_ALL |  |
+
+#### Returns
+
+`number`
+
+#### Inherited from
+
+TransformNode.billboardMode
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:69
+
+• `set` **billboardMode**(`value`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `value` | `number` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.billboardMode
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:70
+
+___
+
+### doNotSerialize
+
+• `get` **doNotSerialize**(): `boolean`
+
+Gets or sets a boolean used to define if the node must be serialized
+
+#### Returns
+
+`boolean`
+
+#### Inherited from
+
+TransformNode.doNotSerialize
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:90
+
+• `set` **doNotSerialize**(`value`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `value` | `boolean` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.doNotSerialize
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:91
+
+___
+
+### forward
+
+• `get` **forward**(): `Vector3`
+
+The forward direction of that transform in world space.
+
+#### Returns
+
+`Vector3`
+
+#### Inherited from
+
+TransformNode.forward
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:157
+
+___
+
+### infiniteDistance
+
+• `get` **infiniteDistance**(): `boolean`
+
+Gets or sets the distance of the object to max, often used by skybox
+
+#### Returns
+
+`boolean`
+
+#### Inherited from
+
+TransformNode.infiniteDistance
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:87
+
+• `set` **infiniteDistance**(`value`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `value` | `boolean` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.infiniteDistance
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:88
+
+___
+
+### isWorldMatrixFrozen
+
+• `get` **isWorldMatrixFrozen**(): `boolean`
+
+True if the World matrix has been frozen.
+
+#### Returns
+
+`boolean`
+
+#### Inherited from
+
+TransformNode.isWorldMatrixFrozen
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:241
+
+___
+
+### nonUniformScaling
+
+• `get` **nonUniformScaling**(): `boolean`
+
+True if the scaling property of this object is non uniform eg. (1,2,1)
+
+#### Returns
+
+`boolean`
+
+#### Inherited from
+
+TransformNode.nonUniformScaling
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:372
+
+___
+
+### onClonedObservable
+
+• `get` **onClonedObservable**(): `Observable`\<`Node`\>
+
+An event triggered when the node is cloned
+
+#### Returns
+
+`Observable`\<`Node`\>
+
+#### Inherited from
+
+TransformNode.onClonedObservable
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:177
+
+___
+
+### onDispose
+
+• `set` **onDispose**(`callback`): `void`
+
+Sets a callback that will be raised when the node will be disposed
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `callback` | () => `void` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.onDispose
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:169
+
+___
+
+### onEnabledStateChangedObservable
+
+• `get` **onEnabledStateChangedObservable**(): `Observable`\<`boolean`\>
+
+An event triggered when the enabled state of the node changes
+
+#### Returns
+
+`Observable`\<`boolean`\>
+
+#### Inherited from
+
+TransformNode.onEnabledStateChangedObservable
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:173
+
+___
+
+### parent
+
+• `get` **parent**(): `Node`
+
+#### Returns
+
+`Node`
+
+#### Inherited from
+
+TransformNode.parent
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:139
+
+• `set` **parent**(`parent`): `void`
+
+Gets or sets the parent of the node (without keeping the current position in the scene)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `parent` | `Node` |
+
+#### Returns
+
+`void`
+
+**`See`**
+
+https://doc.babylonjs.com/features/featuresDeepDive/mesh/transforms/parent_pivot/parent
+
+#### Inherited from
+
+TransformNode.parent
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:138
+
+___
+
+### position
+
+• `get` **position**(): `Vector3`
+
+Gets or set the node position (default is (0.0, 0.0, 0.0))
+
+#### Returns
+
+`Vector3`
+
+#### Inherited from
+
+TransformNode.position
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:126
+
+• `set` **position**(`newPosition`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `newPosition` | `Vector3` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.position
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:127
+
+___
+
+### preserveParentRotationForBillboard
+
+• `get` **preserveParentRotationForBillboard**(): `boolean`
+
+Gets or sets a boolean indicating that parent rotation should be preserved when using billboards.
+This could be useful for glTF objects where parent rotation helps converting from right handed to left handed
+
+#### Returns
+
+`boolean`
+
+#### Inherited from
+
+TransformNode.preserveParentRotationForBillboard
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:76
+
+• `set` **preserveParentRotationForBillboard**(`value`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `value` | `boolean` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.preserveParentRotationForBillboard
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:77
+
+___
+
+### right
+
+• `get` **right**(): `Vector3`
+
+The right direction of that transform in world space.
+
+#### Returns
+
+`Vector3`
+
+#### Inherited from
+
+TransformNode.right
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:165
+
+___
+
+### rotation
+
+• `get` **rotation**(): `Vector3`
+
+Gets or sets the rotation property : a Vector3 defining the rotation value in radians around each local axis X, Y, Z  (default is (0.0, 0.0, 0.0)).
+If rotation quaternion is set, this Vector3 will be ignored and copy from the quaternion
+
+#### Returns
+
+`Vector3`
+
+#### Inherited from
+
+TransformNode.rotation
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:141
+
+• `set` **rotation**(`newRotation`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `newRotation` | `Vector3` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.rotation
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:142
+
+___
+
+### rotationQuaternion
+
+• `get` **rotationQuaternion**(): `Quaternion`
+
+Gets or sets the rotation Quaternion property : this a Quaternion object defining the node rotation by using a unit quaternion (undefined by default, but can be null).
+If set, only the rotationQuaternion is then used to compute the node rotation (ie. node.rotation will be ignored)
+
+#### Returns
+
+`Quaternion`
+
+#### Inherited from
+
+TransformNode.rotationQuaternion
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:152
+
+• `set` **rotationQuaternion**(`quaternion`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `quaternion` | `Quaternion` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.rotationQuaternion
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:153
+
+___
+
+### scaling
+
+• `get` **scaling**(): `Vector3`
+
+Gets or sets the scaling property : a Vector3 defining the node scaling along each local axis X, Y, Z (default is (1.0, 1.0, 1.0)).
+
+#### Returns
+
+`Vector3`
+
+#### Inherited from
+
+TransformNode.scaling
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:146
+
+• `set` **scaling**(`newScaling`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `newScaling` | `Vector3` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.scaling
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:147
+
+___
+
+### up
+
+• `get` **up**(): `Vector3`
+
+The up direction of that transform in world space.
+
+#### Returns
+
+`Vector3`
+
+#### Inherited from
+
+TransformNode.up
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:161
+
+___
+
+### worldMatrixFromCache
+
+• `get` **worldMatrixFromCache**(): `Matrix`
+
+Returns directly the latest state of the mesh World matrix.
+A Matrix is returned.
+
+#### Returns
+
+`Matrix`
+
+#### Inherited from
+
+TransformNode.worldMatrixFromCache
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:234
+
+## Methods
+
+### \_addToSceneRootNodes
+
+▸ **_addToSceneRootNodes**(): `void`
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.\_addToSceneRootNodes
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:145
+
+___
+
+### \_afterComputeWorldMatrix
+
+▸ **_afterComputeWorldMatrix**(): `void`
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.\_afterComputeWorldMatrix
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:462
+
+___
+
+### \_getActionManagerForTrigger
+
+▸ **_getActionManagerForTrigger**(`trigger?`, `_initialCall?`): `AbstractActionManager`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `trigger?` | `number` |
+| `_initialCall?` | `boolean` |
+
+#### Returns
+
+`AbstractActionManager`
+
+#### Inherited from
+
+TransformNode.\_getActionManagerForTrigger
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:244
+
+___
+
+### \_getDescendants
+
+▸ **_getDescendants**(`results`, `directDescendantsOnly?`, `predicate?`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `results` | `Node`[] |
+| `directDescendantsOnly?` | `boolean` |
+| `predicate?` | (`node`: `Node`) => `boolean` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.\_getDescendants
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:293
+
+___
+
+### \_getEffectiveParent
+
+▸ **_getEffectiveParent**(): `Node`
+
+#### Returns
+
+`Node`
+
+#### Inherited from
+
+TransformNode.\_getEffectiveParent
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:443
+
+___
+
+### \_getWorldMatrixDeterminant
+
+▸ **_getWorldMatrixDeterminant**(): `number`
+
+#### Returns
+
+`number`
+
+#### Inherited from
+
+TransformNode.\_getWorldMatrixDeterminant
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:229
+
+___
+
+### \_initCache
+
+▸ **_initCache**(): `void`
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.\_initCache
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:180
+
+___
+
+### \_isSynchronized
+
+▸ **_isSynchronized**(): `boolean`
+
+#### Returns
+
+`boolean`
+
+#### Inherited from
+
+TransformNode.\_isSynchronized
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:178
+
+___
+
+### \_markSyncedWithParent
+
+▸ **_markSyncedWithParent**(): `void`
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.\_markSyncedWithParent
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:252
+
+___
+
+### \_removeFromSceneRootNodes
+
+▸ **_removeFromSceneRootNodes**(): `void`
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.\_removeFromSceneRootNodes
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:147
+
+___
+
+### \_serializeAsParent
+
+▸ **_serializeAsParent**(`serializationObject`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `serializationObject` | `any` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.\_serializeAsParent
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:143
+
+___
+
+### \_setReady
+
+▸ **_setReady**(`state`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `state` | `boolean` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.\_setReady
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:339
+
+___
+
+### \_syncParentEnabledState
+
+▸ **_syncParentEnabledState**(): `void`
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.\_syncParentEnabledState
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:277
+
+___
+
+### \_updateCache
+
+▸ **_updateCache**(`_ignoreParentClass?`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `_ignoreParentClass?` | `boolean` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.\_updateCache
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:248
+
+___
+
+### \_updateNonUniformScalingState
+
+▸ **_updateNonUniformScalingState**(`value`): `boolean`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `value` | `boolean` |
+
+#### Returns
+
+`boolean`
+
+#### Inherited from
+
+TransformNode.\_updateNonUniformScalingState
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:376
+
+___
+
+### addBehavior
+
+▸ **addBehavior**(`behavior`, `attachImmediately?`): `Node`
+
+Attach a behavior to the node
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `behavior` | `Behavior`\<`Node`\> | defines the behavior to attach |
+| `attachImmediately?` | `boolean` | defines that the behavior must be attached even if the scene is still loading |
+
+#### Returns
+
+`Node`
+
+the current Node
+
+**`See`**
+
+https://doc.babylonjs.com/features/featuresDeepDive/behaviors
+
+#### Inherited from
+
+TransformNode.addBehavior
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:203
+
+___
+
+### addChild
+
+▸ **addChild**(`mesh`, `preserveScalingSign?`): `this`
+
+Adds the passed mesh as a child to the current mesh
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `mesh` | `TransformNode` | defines the child mesh |
+| `preserveScalingSign?` | `boolean` | if true, keep scaling sign of child. Otherwise, scaling sign might change. |
+
+#### Returns
+
+`this`
+
+the current mesh
+
+#### Inherited from
+
+TransformNode.addChild
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:360
+
+___
+
+### addRotation
+
+▸ **addRotation**(`x`, `y`, `z`): `TransformNode`
+
+Adds a rotation step to the mesh current rotation.
+x, y, z are Euler angles expressed in radians.
+This methods updates the current mesh rotation, either mesh.rotation, either mesh.rotationQuaternion if it's set.
+This means this rotation is made in the mesh local space only.
+It's useful to set a custom rotation order different from the BJS standard one YXZ.
+Example : this rotates the mesh first around its local X axis, then around its local Z axis, finally around its local Y axis.
+```javascript
+mesh.addRotation(x1, 0, 0).addRotation(0, 0, z2).addRotation(0, 0, y3);
+```
+Note that `addRotation()` accumulates the passed rotation values to the current ones and computes the .rotation or .rotationQuaternion updated values.
+Under the hood, only quaternions are used. So it's a little faster is you use .rotationQuaternion because it doesn't need to translate them back to Euler angles.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `x` | `number` | Rotation to add |
+| `y` | `number` | Rotation to add |
+| `z` | `number` | Rotation to add |
+
+#### Returns
+
+`TransformNode`
+
+the TransformNode.
+
+#### Inherited from
+
+TransformNode.addRotation
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:439
+
+___
+
+### applyAngularImpulse
+
+▸ **applyAngularImpulse**(`angularImpulse`): `TransformNode`
+
+Apply a physic angular impulse to the mesh
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `angularImpulse` | `Vector3` | defines the torque to apply |
+
+#### Returns
+
+`TransformNode`
+
+the current mesh
+
+#### Inherited from
+
+TransformNode.applyAngularImpulse
+
+#### Defined in
+
+node_modules/@babylonjs/core/Physics/v2/physicsEngineComponent.d.ts:33
+
+___
+
+### applyImpulse
+
+▸ **applyImpulse**(`force`, `contactPoint`): `TransformNode`
+
+Apply a physic impulse to the mesh
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `force` | `Vector3` | defines the force to apply |
+| `contactPoint` | `Vector3` | defines where to apply the force |
+
+#### Returns
+
+`TransformNode`
+
+the current mesh
+
+#### Inherited from
+
+TransformNode.applyImpulse
+
+#### Defined in
+
+node_modules/@babylonjs/core/Physics/v2/physicsEngineComponent.d.ts:28
+
+___
+
+### attachToBone
+
+▸ **attachToBone**(`bone`, `affectedTransformNode`): `TransformNode`
+
+Attach the current TransformNode to another TransformNode associated with a bone
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `bone` | `Bone` | Bone affecting the TransformNode |
+| `affectedTransformNode` | `TransformNode` | TransformNode associated with the bone |
+
+#### Returns
+
+`TransformNode`
+
+this object
+
+#### Inherited from
+
+TransformNode.attachToBone
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:383
+
+___
+
+### beginAnimation
+
+▸ **beginAnimation**(`name`, `loop?`, `speedRatio?`, `onAnimationEnd?`): `Animatable`
+
+Will start the animation sequence
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `name` | `string` | defines the range frames for animation sequence |
+| `loop?` | `boolean` | defines if the animation should loop (false by default) |
+| `speedRatio?` | `number` | defines the speed factor in which to run the animation (1 by default) |
+| `onAnimationEnd?` | () => `void` | defines a function to be executed when the animation ended (undefined by default) |
+
+#### Returns
+
+`Animatable`
+
+the object created for this animation. If range does not exist, it will return null
+
+#### Inherited from
+
+TransformNode.beginAnimation
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:386
+
+___
+
+### clone
+
+▸ **clone**(`name`, `newParent`, `doNotCloneChildren?`): `TransformNode`
+
+Clone the current transform node
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `name` | `string` | Name of the new clone |
+| `newParent` | `Node` | New parent for the clone |
+| `doNotCloneChildren?` | `boolean` | Do not clone children hierarchy |
+
+#### Returns
+
+`TransformNode`
+
+the new transform node
+
+#### Inherited from
+
+TransformNode.clone
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:495
+
+___
+
+### computeWorldMatrix
+
+▸ **computeWorldMatrix**(`force?`, `camera?`): `Matrix`
+
+Computes the world matrix of the node
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `force?` | `boolean` | defines if the cache version should be invalidated forcing the world matrix to be created from scratch |
+| `camera?` | `Camera` | defines the camera used if different from the scene active camera (This is used with modes like Billboard or infinite distance) |
+
+#### Returns
+
+`Matrix`
+
+the world matrix
+
+#### Inherited from
+
+TransformNode.computeWorldMatrix
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:456
+
+___
+
+### createAnimationRange
+
+▸ **createAnimationRange**(`name`, `from`, `to`): `void`
+
+Creates an animation range for this node
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `name` | `string` | defines the name of the range |
+| `from` | `number` | defines the starting key |
+| `to` | `number` | defines the end key |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.createAnimationRange
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:352
+
+___
+
+### deleteAnimationRange
+
+▸ **deleteAnimationRange**(`name`, `deleteFrames?`): `void`
+
+Delete a specific animation range
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `name` | `string` | defines the name of the range to delete |
+| `deleteFrames?` | `boolean` | defines if animation frames from the range must be deleted as well |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.deleteAnimationRange
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:358
+
+___
+
+### detachFromBone
+
+▸ **detachFromBone**(`resetToPreviousParent?`): `TransformNode`
+
+Detach the transform node if its associated with a bone
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `resetToPreviousParent?` | `boolean` | Indicates if the parent that was in effect when attachToBone was called should be set back or if we should set parent to null instead (defaults to the latter) |
+
+#### Returns
+
+`TransformNode`
+
+this object
+
+#### Inherited from
+
+TransformNode.detachFromBone
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:389
+
+___
+
+### dispose
+
+▸ **dispose**(`doNotRecurse?`, `disposeMaterialAndTextures?`): `void`
+
+Releases resources associated with this transform node.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `doNotRecurse?` | `boolean` | Set to true to not recurse into each children (recurse into each children by default) |
+| `disposeMaterialAndTextures?` | `boolean` | Set to true to also dispose referenced materials and textures (false by default) |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.dispose
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:522
+
+___
+
+### freezeWorldMatrix
+
+▸ **freezeWorldMatrix**(`newWorldMatrix?`, `decompose?`): `TransformNode`
+
+Prevents the World matrix to be computed any longer
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `newWorldMatrix?` | `Matrix` | defines an optional matrix to use as world matrix |
+| `decompose?` | `boolean` | defines whether to decompose the given newWorldMatrix or directly assign |
+
+#### Returns
+
+`TransformNode`
+
+the TransformNode.
+
+#### Inherited from
+
+TransformNode.freezeWorldMatrix
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:232
+
+___
+
+### getAbsolutePivotPoint
+
+▸ **getAbsolutePivotPoint**(): `Vector3`
+
+Returns a new Vector3 set with the mesh pivot point World coordinates.
+
+#### Returns
+
+`Vector3`
+
+a new Vector3 set with the mesh pivot point World coordinates.
+
+#### Inherited from
+
+TransformNode.getAbsolutePivotPoint
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:328
+
+___
+
+### getAbsolutePivotPointToRef
+
+▸ **getAbsolutePivotPointToRef**(`result`): `TransformNode`
+
+Sets the Vector3 "result" coordinates with the mesh pivot point World coordinates.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `result` | `Vector3` | vector3 to store the result |
+
+#### Returns
+
+`TransformNode`
+
+this TransformNode.
+
+#### Inherited from
+
+TransformNode.getAbsolutePivotPointToRef
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:334
+
+___
+
+### getAbsolutePosition
+
+▸ **getAbsolutePosition**(): `Vector3`
+
+Returns the mesh absolute position in the World.
+
+#### Returns
+
+`Vector3`
+
+a Vector3.
+
+#### Inherited from
+
+TransformNode.getAbsolutePosition
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:246
+
+___
+
+### getAnimationByName
+
+▸ **getAnimationByName**(`name`): `Animation`
+
+Get an animation by name
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `name` | `string` | defines the name of the animation to look for |
+
+#### Returns
+
+`Animation`
+
+null if not found else the requested animation
+
+#### Inherited from
+
+TransformNode.getAnimationByName
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:345
+
+___
+
+### getAnimationRange
+
+▸ **getAnimationRange**(`name`): `AnimationRange`
+
+Get an animation range by name
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `name` | `string` | defines the name of the animation range to look for |
+
+#### Returns
+
+`AnimationRange`
+
+null if not found else the requested animation range
+
+#### Inherited from
+
+TransformNode.getAnimationRange
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:364
+
+___
+
+### getAnimationRanges
+
+▸ **getAnimationRanges**(): `AnimationRange`[]
+
+Gets the list of all animation ranges defined on this node
+
+#### Returns
+
+`AnimationRange`[]
+
+an array
+
+#### Inherited from
+
+TransformNode.getAnimationRanges
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:377
+
+___
+
+### getBehaviorByName
+
+▸ **getBehaviorByName**(`name`): `Behavior`\<`Node`\>
+
+Gets an attached behavior by name
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `name` | `string` | defines the name of the behavior to look for |
+
+#### Returns
+
+`Behavior`\<`Node`\>
+
+null if behavior was not found else the requested behavior
+
+**`See`**
+
+https://doc.babylonjs.com/features/featuresDeepDive/behaviors
+
+#### Inherited from
+
+TransformNode.getBehaviorByName
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:222
+
+___
+
+### getChildMeshes
+
+▸ **getChildMeshes**\<`T`\>(`directDescendantsOnly?`, `predicate?`): `T`[]
+
+Get all child-meshes of this node
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `AbstractMesh` |
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `directDescendantsOnly?` | `boolean` | defines if true only direct descendants of 'this' will be considered, if false direct and also indirect (children of children, an so on in a recursive manner) descendants of 'this' will be considered (Default: false) |
+| `predicate?` | (`node`: `Node`) => node is T | defines an optional predicate that will be called on every evaluated child, the predicate must return true for a given child to be part of the result, otherwise it will be ignored |
+
+#### Returns
+
+`T`[]
+
+an array of AbstractMesh
+
+#### Inherited from
+
+TransformNode.getChildMeshes
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:314
+
+▸ **getChildMeshes**(`directDescendantsOnly?`, `predicate?`): `AbstractMesh`[]
+
+Get all child-meshes of this node
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `directDescendantsOnly?` | `boolean` | defines if true only direct descendants of 'this' will be considered, if false direct and also indirect (children of children, an so on in a recursive manner) descendants of 'this' will be considered (Default: false) |
+| `predicate?` | (`node`: `Node`) => `boolean` | defines an optional predicate that will be called on every evaluated child, the predicate must return true for a given child to be part of the result, otherwise it will be ignored |
+
+#### Returns
+
+`AbstractMesh`[]
+
+an array of AbstractMesh
+
+#### Inherited from
+
+TransformNode.getChildMeshes
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:321
+
+___
+
+### getChildTransformNodes
+
+▸ **getChildTransformNodes**(`directDescendantsOnly?`, `predicate?`): `TransformNode`[]
+
+Get all child-transformNodes of this node
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `directDescendantsOnly?` | `boolean` | defines if true only direct descendants of 'this' will be considered, if false direct and also indirect (children of children, an so on in a recursive manner) descendants of 'this' will be considered |
+| `predicate?` | (`node`: `Node`) => `boolean` | defines an optional predicate that will be called on every evaluated child, the predicate must return true for a given child to be part of the result, otherwise it will be ignored |
+
+#### Returns
+
+`TransformNode`[]
+
+an array of TransformNode
+
+#### Inherited from
+
+TransformNode.getChildTransformNodes
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:516
+
+___
+
+### getChildren
+
+▸ **getChildren**\<`T`\>(`predicate?`, `directDescendantsOnly?`): `T`[]
+
+Get all direct children of this node
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `Node` |
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `predicate?` | (`node`: `Node`) => node is T | defines an optional predicate that will be called on every evaluated child, the predicate must return true for a given child to be part of the result, otherwise it will be ignored |
+| `directDescendantsOnly?` | `boolean` | defines if true only direct descendants of 'this' will be considered, if false direct and also indirect (children of children, an so on in a recursive manner) descendants of 'this' will be considered (Default: true) |
+
+#### Returns
+
+`T`[]
+
+an array of Node
+
+#### Inherited from
+
+TransformNode.getChildren
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:328
+
+▸ **getChildren**(`predicate?`, `directDescendantsOnly?`): `Node`[]
+
+Get all direct children of this node
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `predicate?` | (`node`: `Node`) => `boolean` | defines an optional predicate that will be called on every evaluated child, the predicate must return true for a given child to be part of the result, otherwise it will be ignored |
+| `directDescendantsOnly?` | `boolean` | defines if true only direct descendants of 'this' will be considered, if false direct and also indirect (children of children, an so on in a recursive manner) descendants of 'this' will be considered (Default: true) |
+
+#### Returns
+
+`Node`[]
+
+an array of Node
+
+#### Inherited from
+
+TransformNode.getChildren
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:335
+
+___
+
+### getClassName
+
+▸ **getClassName**(): `string`
+
+Gets a string identifying the name of the class
+
+#### Returns
+
+`string`
+
+"TransformNode" string
+
+#### Inherited from
+
+TransformNode.getClassName
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:122
+
+___
+
+### getDescendants
+
+▸ **getDescendants**\<`T`\>(`directDescendantsOnly?`, `predicate?`): `T`[]
+
+Will return all nodes that have this node as ascendant
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `Node` |
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `directDescendantsOnly?` | `boolean` | defines if true only direct descendants of 'this' will be considered, if false direct and also indirect (children of children, an so on in a recursive manner) descendants of 'this' will be considered |
+| `predicate?` | (`node`: `Node`) => node is T | defines an optional predicate that will be called on every evaluated child, the predicate must return true for a given child to be part of the result, otherwise it will be ignored |
+
+#### Returns
+
+`T`[]
+
+all children nodes of all types
+
+#### Inherited from
+
+TransformNode.getDescendants
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:300
+
+▸ **getDescendants**(`directDescendantsOnly?`, `predicate?`): `Node`[]
+
+Will return all nodes that have this node as ascendant
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `directDescendantsOnly?` | `boolean` | defines if true only direct descendants of 'this' will be considered, if false direct and also indirect (children of children, an so on in a recursive manner) descendants of 'this' will be considered |
+| `predicate?` | (`node`: `Node`) => `boolean` | defines an optional predicate that will be called on every evaluated child, the predicate must return true for a given child to be part of the result, otherwise it will be ignored |
+
+#### Returns
+
+`Node`[]
+
+all children nodes of all types
+
+#### Inherited from
+
+TransformNode.getDescendants
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:307
+
+___
+
+### getDirection
+
+▸ **getDirection**(`localAxis`): `Vector3`
+
+Returns a new Vector3 that is the localAxis, expressed in the mesh local space, rotated like the mesh.
+This Vector3 is expressed in the World space.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `localAxis` | `Vector3` | axis to rotate |
+
+#### Returns
+
+`Vector3`
+
+a new Vector3 that is the localAxis, expressed in the mesh local space, rotated like the mesh.
+
+#### Inherited from
+
+TransformNode.getDirection
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:287
+
+___
+
+### getDirectionToRef
+
+▸ **getDirectionToRef**(`localAxis`, `result`): `TransformNode`
+
+Sets the Vector3 "result" as the rotated Vector3 "localAxis" in the same rotation than the mesh.
+localAxis is expressed in the mesh local space.
+result is computed in the World space from the mesh World matrix.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `localAxis` | `Vector3` | axis to rotate |
+| `result` | `Vector3` | the resulting transformnode |
+
+#### Returns
+
+`TransformNode`
+
+this TransformNode.
+
+#### Inherited from
+
+TransformNode.getDirectionToRef
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:296
+
+___
+
+### getDistanceToCamera
+
+▸ **getDistanceToCamera**(`camera?`): `number`
+
+Returns the distance from the mesh to the active camera
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `camera?` | `Camera` | defines the camera to use |
+
+#### Returns
+
+`number`
+
+the distance
+
+#### Inherited from
+
+TransformNode.getDistanceToCamera
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:487
+
+___
+
+### getEngine
+
+▸ **getEngine**(): `AbstractEngine`
+
+Gets the engine of the node
+
+#### Returns
+
+`AbstractEngine`
+
+a Engine
+
+#### Inherited from
+
+TransformNode.getEngine
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:194
+
+___
+
+### getHierarchyBoundingVectors
+
+▸ **getHierarchyBoundingVectors**(`includeDescendants?`, `predicate?`): `Object`
+
+Return the minimum and maximum world vectors of the entire hierarchy under current node
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `includeDescendants?` | `boolean` | Include bounding info from descendants as well (true by default) |
+| `predicate?` | (`abstractMesh`: `AbstractMesh`) => `boolean` | defines a callback function that can be customize to filter what meshes should be included in the list used to compute the bounding vectors |
+
+#### Returns
+
+`Object`
+
+the new bounding vectors
+
+| Name | Type |
+| :------ | :------ |
+| `max` | `Vector3` |
+| `min` | `Vector3` |
+
+#### Inherited from
+
+TransformNode.getHierarchyBoundingVectors
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:417
+
+___
+
+### getPhysicsBody
+
+▸ **getPhysicsBody**(): `PhysicsBody`
+
+#### Returns
+
+`PhysicsBody`
+
+#### Inherited from
+
+TransformNode.getPhysicsBody
+
+#### Defined in
+
+node_modules/@babylonjs/core/Physics/v2/physicsEngineComponent.d.ts:22
+
+___
+
+### getPivotMatrix
+
+▸ **getPivotMatrix**(): `Matrix`
+
+Returns the mesh pivot matrix.
+Default : Identity.
+
+#### Returns
+
+`Matrix`
+
+the matrix
+
+#### Inherited from
+
+TransformNode.getPivotMatrix
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:214
+
+___
+
+### getPivotPoint
+
+▸ **getPivotPoint**(): `Vector3`
+
+Returns a new Vector3 set with the mesh pivot point coordinates in the local space.
+
+#### Returns
+
+`Vector3`
+
+the pivot point
+
+#### Inherited from
+
+TransformNode.getPivotPoint
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:317
+
+___
+
+### getPivotPointToRef
+
+▸ **getPivotPointToRef**(`result`): `TransformNode`
+
+Sets the passed Vector3 "result" with the coordinates of the mesh pivot point in the local space.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `result` | `Vector3` | the vector3 to store the result |
+
+#### Returns
+
+`TransformNode`
+
+this TransformNode.
+
+#### Inherited from
+
+TransformNode.getPivotPointToRef
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:323
+
+___
+
+### getPoseMatrix
+
+▸ **getPoseMatrix**(): `Matrix`
+
+Returns the mesh Pose matrix.
+
+#### Returns
+
+`Matrix`
+
+the pose matrix
+
+#### Inherited from
+
+TransformNode.getPoseMatrix
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:176
+
+___
+
+### getPositionExpressedInLocalSpace
+
+▸ **getPositionExpressedInLocalSpace**(): `Vector3`
+
+Returns the mesh position in the local space from the current World matrix values.
+
+#### Returns
+
+`Vector3`
+
+a new Vector3.
+
+#### Inherited from
+
+TransformNode.getPositionExpressedInLocalSpace
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:263
+
+___
+
+### getPositionInCameraSpace
+
+▸ **getPositionInCameraSpace**(`camera?`): `Vector3`
+
+Gets the position of the current mesh in camera space
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `camera?` | `Camera` | defines the camera to use |
+
+#### Returns
+
+`Vector3`
+
+a position
+
+#### Inherited from
+
+TransformNode.getPositionInCameraSpace
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:481
+
+___
+
+### getScene
+
+▸ **getScene**(): `Scene`
+
+Gets the scene of the node
+
+#### Returns
+
+`Scene`
+
+a scene
+
+#### Inherited from
+
+TransformNode.getScene
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:189
+
+___
+
+### getWorldMatrix
+
+▸ **getWorldMatrix**(): `Matrix`
+
+Returns the latest update of the World matrix
+
+#### Returns
+
+`Matrix`
+
+a Matrix
+
+#### Inherited from
+
+TransformNode.getWorldMatrix
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:227
+
+___
+
+### instantiateHierarchy
+
+▸ **instantiateHierarchy**(`newParent?`, `options?`, `onNewNodeCreated?`): `TransformNode`
+
+Instantiate (when possible) or clone that node with its hierarchy
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `newParent?` | `TransformNode` | defines the new parent to use for the instance (or clone) |
+| `options?` | `Object` | defines options to configure how copy is done |
+| `options.doNotInstantiate` | `boolean` \| (`node`: `TransformNode`) => `boolean` | defines if the model must be instantiated or just cloned |
+| `onNewNodeCreated?` | (`source`: `TransformNode`, `clone`: `TransformNode`) => `void` | defines an option callback to call when a clone or an instance is created |
+
+#### Returns
+
+`TransformNode`
+
+an instance (or a clone) of the current node with its hierarchy
+
+#### Inherited from
+
+TransformNode.instantiateHierarchy
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:223
+
+___
+
+### isDescendantOf
+
+▸ **isDescendantOf**(`ancestor`): `boolean`
+
+Is this node a descendant of the given node?
+The function will iterate up the hierarchy until the ancestor was found or no more parents defined
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `ancestor` | `Node` | defines the parent node to inspect |
+
+#### Returns
+
+`boolean`
+
+a boolean indicating if this node is a descendant of the given node
+
+#### Inherited from
+
+TransformNode.isDescendantOf
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:289
+
+___
+
+### isDisposed
+
+▸ **isDisposed**(): `boolean`
+
+Gets a boolean indicating if the node has been disposed
+
+#### Returns
+
+`boolean`
+
+true if the node was disposed
+
+#### Inherited from
+
+TransformNode.isDisposed
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:133
+
+___
+
+### isEnabled
+
+▸ **isEnabled**(`checkAncestors?`): `boolean`
+
+Is this node enabled?
+If the node has a parent, all ancestors will be checked and false will be returned if any are false (not enabled), otherwise will return true
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `checkAncestors?` | `boolean` | indicates if this method should check the ancestors. The default is to check the ancestors. If set to false, the method will return the value of this node without checking ancestors |
+
+#### Returns
+
+`boolean`
+
+whether this node (and its parent) is enabled
+
+#### Inherited from
+
+TransformNode.isEnabled
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:275
+
+___
+
+### isReady
+
+▸ **isReady**(`_completeCheck?`): `boolean`
+
+Is this node ready to be used/rendered
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `_completeCheck?` | `boolean` | defines if a complete check (including materials and lights) has to be done (false by default) |
+
+#### Returns
+
+`boolean`
+
+true if the node is ready
+
+#### Inherited from
+
+TransformNode.isReady
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:262
+
+___
+
+### isSynchronized
+
+▸ **isSynchronized**(): `boolean`
+
+#### Returns
+
+`boolean`
+
+#### Inherited from
+
+TransformNode.isSynchronized
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:256
+
+___
+
+### isSynchronizedWithParent
+
+▸ **isSynchronizedWithParent**(): `boolean`
+
+#### Returns
+
+`boolean`
+
+#### Inherited from
+
+TransformNode.isSynchronizedWithParent
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:254
+
+___
+
+### isUsingPivotMatrix
+
+▸ **isUsingPivotMatrix**(): `boolean`
+
+return true if a pivot has been set
+
+#### Returns
+
+`boolean`
+
+true if a pivot matrix is used
+
+#### Inherited from
+
+TransformNode.isUsingPivotMatrix
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:132
+
+___
+
+### isUsingPostMultiplyPivotMatrix
+
+▸ **isUsingPostMultiplyPivotMatrix**(): `boolean`
+
+#### Returns
+
+`boolean`
+
+true if pivot matrix must be cancelled in the world matrix. When this parameter is set to true (default), the inverse of the pivot matrix is also applied at the end to cancel the transformation effect.
+
+#### Inherited from
+
+TransformNode.isUsingPostMultiplyPivotMatrix
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:136
+
+___
+
+### isWorldMatrixCameraDependent
+
+▸ **isWorldMatrixCameraDependent**(): `boolean`
+
+Returns whether the transform node world matrix computation needs the camera information to be computed.
+This is the case when the node is a billboard or has an infinite distance for instance.
+
+#### Returns
+
+`boolean`
+
+true if the world matrix computation needs the camera information to be computed
+
+#### Inherited from
+
+TransformNode.isWorldMatrixCameraDependent
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:449
+
+___
+
+### locallyTranslate
+
+▸ **locallyTranslate**(`vector3`): `TransformNode`
+
+Translates the mesh along the passed Vector3 in its local space.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `vector3` | `Vector3` | the distance to translate in localspace |
+
+#### Returns
+
+`TransformNode`
+
+the TransformNode.
+
+#### Inherited from
+
+TransformNode.locallyTranslate
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:269
+
+___
+
+### lookAt
+
+▸ **lookAt**(`targetPoint`, `yawCor?`, `pitchCor?`, `rollCor?`, `space?`): `TransformNode`
+
+Orients a mesh towards a target point. Mesh must be drawn facing user.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `targetPoint` | `Vector3` | the position (must be in same space as current mesh) to look at |
+| `yawCor?` | `number` | optional yaw (y-axis) correction in radians |
+| `pitchCor?` | `number` | optional pitch (x-axis) correction in radians |
+| `rollCor?` | `number` | optional roll (z-axis) correction in radians |
+| `space?` | `Space` | the chosen space of the target |
+
+#### Returns
+
+`TransformNode`
+
+the TransformNode.
+
+#### Inherited from
+
+TransformNode.lookAt
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:280
+
+___
+
+### markAsDirty
+
+▸ **markAsDirty**(`property?`): `Node`
+
+Flag the transform node as dirty (Forcing it to update everything)
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `property?` | `string` | if set to "rotation" the objects rotationQuaternion will be set to null |
+
+#### Returns
+
+`Node`
+
+this  node
+
+#### Inherited from
+
+TransformNode.markAsDirty
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:340
+
+___
+
+### normalizeToUnitCube
+
+▸ **normalizeToUnitCube**(`includeDescendants?`, `ignoreRotation?`, `predicate?`): `TransformNode`
+
+Uniformly scales the mesh to fit inside of a unit cube (1 X 1 X 1 units)
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `includeDescendants?` | `boolean` | Use the hierarchy's bounding box instead of the mesh's bounding box. Default is false |
+| `ignoreRotation?` | `boolean` | ignore rotation when computing the scale (ie. object will be axis aligned). Default is false |
+| `predicate?` | (`node`: `AbstractMesh`) => `boolean` | predicate that is passed in to getHierarchyBoundingVectors when selecting which object should be included when scaling |
+
+#### Returns
+
+`TransformNode`
+
+the current mesh
+
+#### Inherited from
+
+TransformNode.normalizeToUnitCube
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:530
+
+___
+
+### registerAfterWorldMatrixUpdate
+
+▸ **registerAfterWorldMatrixUpdate**(`func`): `TransformNode`
+
+If you'd like to be called back after the mesh position, rotation or scaling has been updated.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `func` | (`mesh`: `TransformNode`) => `void` | callback function to add |
+
+#### Returns
+
+`TransformNode`
+
+the TransformNode.
+
+#### Inherited from
+
+TransformNode.registerAfterWorldMatrixUpdate
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:469
+
+___
+
+### removeBehavior
+
+▸ **removeBehavior**(`behavior`): `Node`
+
+Remove an attached behavior
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `behavior` | `Behavior`\<`Node`\> | defines the behavior to attach |
+
+#### Returns
+
+`Node`
+
+the current Node
+
+**`See`**
+
+https://doc.babylonjs.com/features/featuresDeepDive/behaviors
+
+#### Inherited from
+
+TransformNode.removeBehavior
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:210
+
+___
+
+### removeChild
+
+▸ **removeChild**(`mesh`, `preserveScalingSign?`): `this`
+
+Removes the passed mesh from the current mesh children list
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `mesh` | `TransformNode` | defines the child mesh |
+| `preserveScalingSign?` | `boolean` | if true, keep scaling sign of child. Otherwise, scaling sign might change. |
+
+#### Returns
+
+`this`
+
+the current mesh
+
+#### Inherited from
+
+TransformNode.removeChild
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:367
+
+___
+
+### resetLocalMatrix
+
+▸ **resetLocalMatrix**(`independentOfChildren?`): `void`
+
+Resets this nodeTransform's local matrix to Matrix.Identity().
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `independentOfChildren?` | `boolean` | indicates if all child nodeTransform's world-space transform should be preserved. |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.resetLocalMatrix
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:461
+
+___
+
+### rotate
+
+▸ **rotate**(`axis`, `amount`, `space?`): `TransformNode`
+
+Rotates the mesh around the axis vector for the passed angle (amount) expressed in radians, in the given space.
+space (default LOCAL) can be either Space.LOCAL, either Space.WORLD.
+Note that the property `rotationQuaternion` is then automatically updated and the property `rotation` is set to (0,0,0) and no longer used.
+The passed axis is also normalized.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `axis` | `Vector3` | the axis to rotate around |
+| `amount` | `number` | the amount to rotate in radians |
+| `space?` | `Space` | Space to rotate in (Default: local) |
+
+#### Returns
+
+`TransformNode`
+
+the TransformNode.
+
+#### Inherited from
+
+TransformNode.rotate
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:401
+
+___
+
+### rotateAround
+
+▸ **rotateAround**(`point`, `axis`, `amount`): `TransformNode`
+
+Rotates the mesh around the axis vector for the passed angle (amount) expressed in radians, in world space.
+Note that the property `rotationQuaternion` is then automatically updated and the property `rotation` is set to (0,0,0) and no longer used.
+The passed axis is also normalized. .
+Method is based on http://www.euclideanspace.com/maths/geometry/affine/aroundPoint/index.htm
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `point` | `Vector3` | the point to rotate around |
+| `axis` | `Vector3` | the axis to rotate around |
+| `amount` | `number` | the amount to rotate in radians |
+
+#### Returns
+
+`TransformNode`
+
+the TransformNode
+
+#### Inherited from
+
+TransformNode.rotateAround
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:412
+
+___
+
+### serialize
+
+▸ **serialize**(`currentSerializationObject?`): `any`
+
+Serializes the objects information.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `currentSerializationObject?` | `any` | defines the object to serialize in |
+
+#### Returns
+
+`any`
+
+the serialized object
+
+#### Inherited from
+
+TransformNode.serialize
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:501
+
+___
+
+### serializeAnimationRanges
+
+▸ **serializeAnimationRanges**(): `any`
+
+Serialize animation ranges into a JSON compatible object
+
+#### Returns
+
+`any`
+
+serialization object
+
+#### Inherited from
+
+TransformNode.serializeAnimationRanges
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:391
+
+___
+
+### setAbsolutePosition
+
+▸ **setAbsolutePosition**(`absolutePosition`): `TransformNode`
+
+Sets the mesh absolute position in the World from a Vector3 or an Array(3).
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `absolutePosition` | `Vector3` | the absolute position to set |
+
+#### Returns
+
+`TransformNode`
+
+the TransformNode.
+
+#### Inherited from
+
+TransformNode.setAbsolutePosition
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:252
+
+___
+
+### setDirection
+
+▸ **setDirection**(`localAxis`, `yawCor?`, `pitchCor?`, `rollCor?`): `TransformNode`
+
+Sets this transform node rotation to the given local axis.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `localAxis` | `Vector3` | the axis in local space |
+| `yawCor?` | `number` | optional yaw (y-axis) correction in radians |
+| `pitchCor?` | `number` | optional pitch (x-axis) correction in radians |
+| `rollCor?` | `number` | optional roll (z-axis) correction in radians |
+
+#### Returns
+
+`TransformNode`
+
+this TransformNode
+
+#### Inherited from
+
+TransformNode.setDirection
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:305
+
+___
+
+### setEnabled
+
+▸ **setEnabled**(`value`): `void`
+
+Set the enabled state of this node
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `value` | `boolean` | defines the new enabled state |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.setEnabled
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:282
+
+___
+
+### setParent
+
+▸ **setParent**(`node`, `preserveScalingSign?`, `updatePivot?`): `TransformNode`
+
+Defines the passed node as the parent of the current node.
+The node will remain exactly where it is and its position / rotation will be updated accordingly.
+Note that if the mesh has a pivot matrix / point defined it will be applied after the parent was updated.
+In that case the node will not remain in the same space as it is, as the pivot will be applied.
+To avoid this, you can set updatePivot to true and the pivot will be updated to identity
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `node` | `Node` | the node ot set as the parent |
+| `preserveScalingSign?` | `boolean` | if true, keep scaling sign of child. Otherwise, scaling sign might change. |
+| `updatePivot?` | `boolean` | if true, update the pivot matrix to keep the node in the same space as before |
+
+#### Returns
+
+`TransformNode`
+
+this TransformNode.
+
+**`See`**
+
+https://doc.babylonjs.com/features/featuresDeepDive/mesh/transforms/parent_pivot/parent
+
+#### Inherited from
+
+TransformNode.setParent
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:353
+
+___
+
+### setPivotMatrix
+
+▸ **setPivotMatrix**(`matrix`, `postMultiplyPivotMatrix?`): `TransformNode`
+
+Sets a new pivot matrix to the current node
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `matrix` | `DeepImmutableObject`\<`Matrix`\> | defines the new pivot matrix to use |
+| `postMultiplyPivotMatrix?` | `boolean` | defines if the pivot matrix must be cancelled in the world matrix. When this parameter is set to true (default), the inverse of the pivot matrix is also applied at the end to cancel the transformation effect |
+
+#### Returns
+
+`TransformNode`
+
+the current TransformNode
+
+#### Inherited from
+
+TransformNode.setPivotMatrix
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:208
+
+___
+
+### setPivotPoint
+
+▸ **setPivotPoint**(`point`, `space?`): `TransformNode`
+
+Sets a new pivot point to the current node
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `point` | `Vector3` | defines the new pivot point to use |
+| `space?` | `Space` | defines if the point is in world or local space (local by default) |
+
+#### Returns
+
+`TransformNode`
+
+the current TransformNode
+
+#### Inherited from
+
+TransformNode.setPivotPoint
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:312
+
+___
+
+### setPositionWithLocalVector
+
+▸ **setPositionWithLocalVector**(`vector3`): `TransformNode`
+
+Sets the mesh position in its local space.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `vector3` | `Vector3` | the position to set in localspace |
+
+#### Returns
+
+`TransformNode`
+
+the TransformNode.
+
+#### Inherited from
+
+TransformNode.setPositionWithLocalVector
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:258
+
+___
+
+### setPreTransformMatrix
+
+▸ **setPreTransformMatrix**(`matrix`): `TransformNode`
+
+Sets a new matrix to apply before all other transformation
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `matrix` | `Matrix` | defines the transform matrix |
+
+#### Returns
+
+`TransformNode`
+
+the current TransformNode
+
+#### Inherited from
+
+TransformNode.setPreTransformMatrix
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:201
 
 ___
 
@@ -307,4 +4281,259 @@ ___
 
 #### Defined in
 
-[prefabs/Axis/Axis.ts:71](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Axis/Axis.ts#L71)
+[src/prefabs/Axis/Axis.ts:70](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Axis/Axis.ts#L70)
+
+___
+
+### translate
+
+▸ **translate**(`axis`, `distance`, `space?`): `TransformNode`
+
+Translates the mesh along the axis vector for the passed distance in the given space.
+space (default LOCAL) can be either Space.LOCAL, either Space.WORLD.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `axis` | `Vector3` | the axis to translate in |
+| `distance` | `number` | the distance to translate |
+| `space?` | `Space` | Space to rotate in (Default: local) |
+
+#### Returns
+
+`TransformNode`
+
+the TransformNode.
+
+#### Inherited from
+
+TransformNode.translate
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:421
+
+___
+
+### unfreezeWorldMatrix
+
+▸ **unfreezeWorldMatrix**(): `this`
+
+Allows back the World matrix computation.
+
+#### Returns
+
+`this`
+
+the TransformNode.
+
+#### Inherited from
+
+TransformNode.unfreezeWorldMatrix
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:237
+
+___
+
+### unregisterAfterWorldMatrixUpdate
+
+▸ **unregisterAfterWorldMatrixUpdate**(`func`): `TransformNode`
+
+Removes a registered callback function.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `func` | (`mesh`: `TransformNode`) => `void` | callback function to remove |
+
+#### Returns
+
+`TransformNode`
+
+the TransformNode.
+
+#### Inherited from
+
+TransformNode.unregisterAfterWorldMatrixUpdate
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:475
+
+___
+
+### updateCache
+
+▸ **updateCache**(`force?`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `force?` | `boolean` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.updateCache
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:240
+
+___
+
+### updatePoseMatrix
+
+▸ **updatePoseMatrix**(`matrix`): `TransformNode`
+
+Copies the parameter passed Matrix into the mesh Pose matrix.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `matrix` | `Matrix` | the matrix to copy the pose from |
+
+#### Returns
+
+`TransformNode`
+
+this TransformNode.
+
+#### Inherited from
+
+TransformNode.updatePoseMatrix
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:171
+
+___
+
+### AddNodeConstructor
+
+▸ **AddNodeConstructor**(`type`, `constructorFunc`): `void`
+
+Add a new node constructor
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `type` | `string` | defines the type name of the node to construct |
+| `constructorFunc` | `NodeConstructor` | defines the constructor function |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.AddNodeConstructor
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:35
+
+___
+
+### Construct
+
+▸ **Construct**(`type`, `name`, `scene`, `options?`): () => `Node`
+
+Returns a node constructor based on type name
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `type` | `string` | defines the type name |
+| `name` | `string` | defines the new node name |
+| `scene` | `Scene` | defines the hosting scene |
+| `options?` | `any` | defines optional options to transmit to constructors |
+
+#### Returns
+
+`fn`
+
+the new constructor or null
+
+▸ (): `Node`
+
+##### Returns
+
+`Node`
+
+#### Inherited from
+
+TransformNode.Construct
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:44
+
+___
+
+### Parse
+
+▸ **Parse**(`parsedTransformNode`, `scene`, `rootUrl`): `TransformNode`
+
+Returns a new TransformNode object parsed from the source provided.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `parsedTransformNode` | `any` | is the source. |
+| `scene` | `Scene` | the scene the object belongs to |
+| `rootUrl` | `string` | is a string, it's the root URL to prefix the `delayLoadingFile` property with |
+
+#### Returns
+
+`TransformNode`
+
+a new TransformNode object parsed from the source provided.
+
+#### Inherited from
+
+TransformNode.Parse
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:509
+
+___
+
+### ParseAnimationRanges
+
+▸ **ParseAnimationRanges**(`node`, `parsedNode`, `_scene`): `void`
+
+Parse animation range data from a serialization object and store them into a given node
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `node` | `Node` | defines where to store the animation ranges |
+| `parsedNode` | `any` | defines the serialization object to read data from |
+| `_scene` | `Scene` | defines the hosting scene |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.ParseAnimationRanges
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:410

--- a/docs/api/classes/Layout.md
+++ b/docs/api/classes/Layout.md
@@ -48,7 +48,7 @@
 
 #### Defined in
 
-[prefabs/Layout/Layout.ts:23](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Layout/Layout.ts#L23)
+[src/prefabs/Layout/Layout.ts:23](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Layout/Layout.ts#L23)
 
 ## Properties
 
@@ -58,7 +58,7 @@
 
 #### Defined in
 
-[prefabs/Layout/Layout.ts:20](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Layout/Layout.ts#L20)
+[src/prefabs/Layout/Layout.ts:20](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Layout/Layout.ts#L20)
 
 ___
 
@@ -68,7 +68,7 @@ ___
 
 #### Defined in
 
-[prefabs/Layout/Layout.ts:17](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Layout/Layout.ts#L17)
+[src/prefabs/Layout/Layout.ts:17](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Layout/Layout.ts#L17)
 
 ___
 
@@ -78,7 +78,7 @@ ___
 
 #### Defined in
 
-[prefabs/Layout/Layout.ts:18](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Layout/Layout.ts#L18)
+[src/prefabs/Layout/Layout.ts:18](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Layout/Layout.ts#L18)
 
 ___
 
@@ -88,7 +88,7 @@ ___
 
 #### Defined in
 
-[prefabs/Layout/Layout.ts:21](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Layout/Layout.ts#L21)
+[src/prefabs/Layout/Layout.ts:21](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Layout/Layout.ts#L21)
 
 ___
 
@@ -98,7 +98,7 @@ ___
 
 #### Defined in
 
-[prefabs/Layout/Layout.ts:19](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Layout/Layout.ts#L19)
+[src/prefabs/Layout/Layout.ts:19](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Layout/Layout.ts#L19)
 
 ## Methods
 
@@ -119,7 +119,7 @@ ___
 
 #### Defined in
 
-[prefabs/Layout/Layout.ts:182](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Layout/Layout.ts#L182)
+[src/prefabs/Layout/Layout.ts:182](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Layout/Layout.ts#L182)
 
 ___
 
@@ -140,7 +140,7 @@ ___
 
 #### Defined in
 
-[prefabs/Layout/Layout.ts:195](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Layout/Layout.ts#L195)
+[src/prefabs/Layout/Layout.ts:195](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Layout/Layout.ts#L195)
 
 ___
 
@@ -161,7 +161,7 @@ ___
 
 #### Defined in
 
-[prefabs/Layout/Layout.ts:210](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Layout/Layout.ts#L210)
+[src/prefabs/Layout/Layout.ts:210](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Layout/Layout.ts#L210)
 
 ___
 
@@ -182,7 +182,7 @@ ___
 
 #### Defined in
 
-[prefabs/Layout/Layout.ts:124](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Layout/Layout.ts#L124)
+[src/prefabs/Layout/Layout.ts:124](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Layout/Layout.ts#L124)
 
 ___
 
@@ -202,7 +202,7 @@ ___
 
 #### Defined in
 
-[prefabs/Layout/Layout.ts:223](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Layout/Layout.ts#L223)
+[src/prefabs/Layout/Layout.ts:223](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Layout/Layout.ts#L223)
 
 ___
 
@@ -216,7 +216,7 @@ ___
 
 #### Defined in
 
-[prefabs/Layout/Layout.ts:53](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Layout/Layout.ts#L53)
+[src/prefabs/Layout/Layout.ts:53](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Layout/Layout.ts#L53)
 
 ___
 
@@ -230,7 +230,7 @@ ___
 
 #### Defined in
 
-[prefabs/Layout/Layout.ts:31](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Layout/Layout.ts#L31)
+[src/prefabs/Layout/Layout.ts:31](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Layout/Layout.ts#L31)
 
 ___
 
@@ -244,7 +244,7 @@ ___
 
 #### Defined in
 
-[prefabs/Layout/Layout.ts:91](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Layout/Layout.ts#L91)
+[src/prefabs/Layout/Layout.ts:91](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Layout/Layout.ts#L91)
 
 ___
 
@@ -258,4 +258,4 @@ ___
 
 #### Defined in
 
-[prefabs/Layout/Layout.ts:171](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Layout/Layout.ts#L171)
+[src/prefabs/Layout/Layout.ts:171](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Layout/Layout.ts#L171)

--- a/docs/api/classes/MeshMap.md
+++ b/docs/api/classes/MeshMap.md
@@ -2,6 +2,12 @@
 
 # Class: MeshMap
 
+## Hierarchy
+
+- `TransformNode`
+
+  ↳ **`MeshMap`**
+
 ## Table of contents
 
 ### Constructors
@@ -10,26 +16,196 @@
 
 ### Properties
 
+- [\_accessibilityTag](MeshMap.md#_accessibilitytag)
+- [\_cache](MeshMap.md#_cache)
+- [\_childUpdateId](MeshMap.md#_childupdateid)
+- [\_children](MeshMap.md#_children)
+- [\_currentRenderId](MeshMap.md#_currentrenderid)
+- [\_disposePhysicsObserver](MeshMap.md#_disposephysicsobserver)
+- [\_indexInSceneTransformNodesArray](MeshMap.md#_indexinscenetransformnodesarray)
+- [\_internalMetadata](MeshMap.md#_internalmetadata)
+- [\_isDirty](MeshMap.md#_isdirty)
+- [\_isNode](MeshMap.md#_isnode)
+- [\_isWorldMatrixFrozen](MeshMap.md#_isworldmatrixfrozen)
+- [\_localMatrix](MeshMap.md#_localmatrix)
+- [\_parentContainer](MeshMap.md#_parentcontainer)
+- [\_parentNode](MeshMap.md#_parentnode)
+- [\_physicsBody](MeshMap.md#_physicsbody)
+- [\_poseMatrix](MeshMap.md#_posematrix)
+- [\_postMultiplyPivotMatrix](MeshMap.md#_postmultiplypivotmatrix)
+- [\_ranges](MeshMap.md#_ranges)
+- [\_scaling](MeshMap.md#_scaling)
+- [\_scene](MeshMap.md#_scene)
+- [\_waitingParentId](MeshMap.md#_waitingparentid)
+- [\_waitingParentInstanceIndex](MeshMap.md#_waitingparentinstanceindex)
+- [\_waitingParsedUniqueId](MeshMap.md#_waitingparseduniqueid)
+- [\_worldMatrix](MeshMap.md#_worldmatrix)
+- [\_worldMatrixDeterminant](MeshMap.md#_worldmatrixdeterminant)
+- [\_worldMatrixDeterminantIsDirty](MeshMap.md#_worldmatrixdeterminantisdirty)
+- [animations](MeshMap.md#animations)
 - [cot](MeshMap.md#cot)
 - [depth](MeshMap.md#depth)
 - [geoJson](MeshMap.md#geojson)
+- [id](MeshMap.md#id)
+- [ignoreNonUniformScaling](MeshMap.md#ignorenonuniformscaling)
+- [inspectableCustomProperties](MeshMap.md#inspectablecustomproperties)
+- [metadata](MeshMap.md#metadata)
 - [name](MeshMap.md#name)
+- [onAccessibilityTagChangedObservable](MeshMap.md#onaccessibilitytagchangedobservable)
+- [onAfterWorldMatrixUpdateObservable](MeshMap.md#onafterworldmatrixupdateobservable)
+- [onDisposeObservable](MeshMap.md#ondisposeobservable)
+- [onReady](MeshMap.md#onready)
+- [physicsBody](MeshMap.md#physicsbody)
 - [projection](MeshMap.md#projection)
+- [reIntegrateRotationIntoRotationQuaternion](MeshMap.md#reintegraterotationintorotationquaternion)
+- [reservedDataStore](MeshMap.md#reserveddatastore)
+- [scalingDeterminant](MeshMap.md#scalingdeterminant)
 - [scene](MeshMap.md#scene)
 - [selection](MeshMap.md#selection)
 - [simplification](MeshMap.md#simplification)
 - [size](MeshMap.md#size)
+- [state](MeshMap.md#state)
 - [transform](MeshMap.md#transform)
+- [uniqueId](MeshMap.md#uniqueid)
+- [BILLBOARDMODE\_ALL](MeshMap.md#billboardmode_all)
+- [BILLBOARDMODE\_NONE](MeshMap.md#billboardmode_none)
+- [BILLBOARDMODE\_USE\_POSITION](MeshMap.md#billboardmode_use_position)
+- [BILLBOARDMODE\_X](MeshMap.md#billboardmode_x)
+- [BILLBOARDMODE\_Y](MeshMap.md#billboardmode_y)
+- [BILLBOARDMODE\_Z](MeshMap.md#billboardmode_z)
+- [BillboardUseParentOrientation](MeshMap.md#billboarduseparentorientation)
+- [\_AnimationRangeFactory](MeshMap.md#_animationrangefactory)
+
+### Accessors
+
+- [absolutePosition](MeshMap.md#absoluteposition)
+- [absoluteRotationQuaternion](MeshMap.md#absoluterotationquaternion)
+- [absoluteScaling](MeshMap.md#absolutescaling)
+- [accessibilityTag](MeshMap.md#accessibilitytag)
+- [animationPropertiesOverride](MeshMap.md#animationpropertiesoverride)
+- [behaviors](MeshMap.md#behaviors)
+- [billboardMode](MeshMap.md#billboardmode)
+- [doNotSerialize](MeshMap.md#donotserialize)
+- [forward](MeshMap.md#forward)
+- [infiniteDistance](MeshMap.md#infinitedistance)
+- [isWorldMatrixFrozen](MeshMap.md#isworldmatrixfrozen)
+- [nonUniformScaling](MeshMap.md#nonuniformscaling)
+- [onClonedObservable](MeshMap.md#onclonedobservable)
+- [onDispose](MeshMap.md#ondispose)
+- [onEnabledStateChangedObservable](MeshMap.md#onenabledstatechangedobservable)
+- [parent](MeshMap.md#parent)
+- [position](MeshMap.md#position)
+- [preserveParentRotationForBillboard](MeshMap.md#preserveparentrotationforbillboard)
+- [right](MeshMap.md#right)
+- [rotation](MeshMap.md#rotation)
+- [rotationQuaternion](MeshMap.md#rotationquaternion)
+- [scaling](MeshMap.md#scaling)
+- [up](MeshMap.md#up)
+- [worldMatrixFromCache](MeshMap.md#worldmatrixfromcache)
 
 ### Methods
 
+- [\_addToSceneRootNodes](MeshMap.md#_addtoscenerootnodes)
+- [\_afterComputeWorldMatrix](MeshMap.md#_aftercomputeworldmatrix)
+- [\_getActionManagerForTrigger](MeshMap.md#_getactionmanagerfortrigger)
+- [\_getDescendants](MeshMap.md#_getdescendants)
+- [\_getEffectiveParent](MeshMap.md#_geteffectiveparent)
+- [\_getWorldMatrixDeterminant](MeshMap.md#_getworldmatrixdeterminant)
+- [\_initCache](MeshMap.md#_initcache)
+- [\_isSynchronized](MeshMap.md#_issynchronized)
+- [\_markSyncedWithParent](MeshMap.md#_marksyncedwithparent)
+- [\_removeFromSceneRootNodes](MeshMap.md#_removefromscenerootnodes)
+- [\_serializeAsParent](MeshMap.md#_serializeasparent)
+- [\_setReady](MeshMap.md#_setready)
+- [\_syncParentEnabledState](MeshMap.md#_syncparentenabledstate)
+- [\_updateCache](MeshMap.md#_updatecache)
+- [\_updateNonUniformScalingState](MeshMap.md#_updatenonuniformscalingstate)
+- [addBehavior](MeshMap.md#addbehavior)
+- [addChild](MeshMap.md#addchild)
+- [addRotation](MeshMap.md#addrotation)
+- [applyAngularImpulse](MeshMap.md#applyangularimpulse)
+- [applyImpulse](MeshMap.md#applyimpulse)
+- [attachToBone](MeshMap.md#attachtobone)
+- [beginAnimation](MeshMap.md#beginanimation)
+- [clone](MeshMap.md#clone)
+- [computeWorldMatrix](MeshMap.md#computeworldmatrix)
+- [createAnimationRange](MeshMap.md#createanimationrange)
 - [createMap](MeshMap.md#createmap)
+- [deleteAnimationRange](MeshMap.md#deleteanimationrange)
+- [detachFromBone](MeshMap.md#detachfrombone)
+- [dispose](MeshMap.md#dispose)
+- [freezeWorldMatrix](MeshMap.md#freezeworldmatrix)
+- [getAbsolutePivotPoint](MeshMap.md#getabsolutepivotpoint)
+- [getAbsolutePivotPointToRef](MeshMap.md#getabsolutepivotpointtoref)
+- [getAbsolutePosition](MeshMap.md#getabsoluteposition)
+- [getAnimationByName](MeshMap.md#getanimationbyname)
+- [getAnimationRange](MeshMap.md#getanimationrange)
+- [getAnimationRanges](MeshMap.md#getanimationranges)
+- [getBehaviorByName](MeshMap.md#getbehaviorbyname)
+- [getChildMeshes](MeshMap.md#getchildmeshes)
+- [getChildTransformNodes](MeshMap.md#getchildtransformnodes)
+- [getChildren](MeshMap.md#getchildren)
+- [getClassName](MeshMap.md#getclassname)
+- [getDescendants](MeshMap.md#getdescendants)
+- [getDirection](MeshMap.md#getdirection)
+- [getDirectionToRef](MeshMap.md#getdirectiontoref)
+- [getDistanceToCamera](MeshMap.md#getdistancetocamera)
+- [getEngine](MeshMap.md#getengine)
+- [getHierarchyBoundingVectors](MeshMap.md#gethierarchyboundingvectors)
+- [getPhysicsBody](MeshMap.md#getphysicsbody)
+- [getPivotMatrix](MeshMap.md#getpivotmatrix)
+- [getPivotPoint](MeshMap.md#getpivotpoint)
+- [getPivotPointToRef](MeshMap.md#getpivotpointtoref)
+- [getPoseMatrix](MeshMap.md#getposematrix)
+- [getPositionExpressedInLocalSpace](MeshMap.md#getpositionexpressedinlocalspace)
+- [getPositionInCameraSpace](MeshMap.md#getpositionincameraspace)
+- [getScene](MeshMap.md#getscene)
+- [getWorldMatrix](MeshMap.md#getworldmatrix)
+- [instantiateHierarchy](MeshMap.md#instantiatehierarchy)
+- [isDescendantOf](MeshMap.md#isdescendantof)
+- [isDisposed](MeshMap.md#isdisposed)
+- [isEnabled](MeshMap.md#isenabled)
+- [isReady](MeshMap.md#isready)
+- [isSynchronized](MeshMap.md#issynchronized)
+- [isSynchronizedWithParent](MeshMap.md#issynchronizedwithparent)
+- [isUsingPivotMatrix](MeshMap.md#isusingpivotmatrix)
+- [isUsingPostMultiplyPivotMatrix](MeshMap.md#isusingpostmultiplypivotmatrix)
+- [isWorldMatrixCameraDependent](MeshMap.md#isworldmatrixcameradependent)
+- [locallyTranslate](MeshMap.md#locallytranslate)
+- [lookAt](MeshMap.md#lookat)
+- [markAsDirty](MeshMap.md#markasdirty)
+- [normalizeToUnitCube](MeshMap.md#normalizetounitcube)
+- [registerAfterWorldMatrixUpdate](MeshMap.md#registerafterworldmatrixupdate)
+- [removeBehavior](MeshMap.md#removebehavior)
+- [removeChild](MeshMap.md#removechild)
+- [resetLocalMatrix](MeshMap.md#resetlocalmatrix)
+- [rotate](MeshMap.md#rotate)
+- [rotateAround](MeshMap.md#rotatearound)
+- [serialize](MeshMap.md#serialize)
+- [serializeAnimationRanges](MeshMap.md#serializeanimationranges)
+- [setAbsolutePosition](MeshMap.md#setabsoluteposition)
+- [setDirection](MeshMap.md#setdirection)
+- [setEnabled](MeshMap.md#setenabled)
+- [setParent](MeshMap.md#setparent)
+- [setPivotMatrix](MeshMap.md#setpivotmatrix)
+- [setPivotPoint](MeshMap.md#setpivotpoint)
+- [setPositionWithLocalVector](MeshMap.md#setpositionwithlocalvector)
+- [setPreTransformMatrix](MeshMap.md#setpretransformmatrix)
+- [translate](MeshMap.md#translate)
+- [unfreezeWorldMatrix](MeshMap.md#unfreezeworldmatrix)
+- [unregisterAfterWorldMatrixUpdate](MeshMap.md#unregisterafterworldmatrixupdate)
+- [updateCache](MeshMap.md#updatecache)
+- [updatePoseMatrix](MeshMap.md#updateposematrix)
+- [AddNodeConstructor](MeshMap.md#addnodeconstructor)
+- [Construct](MeshMap.md#construct)
+- [Parse](MeshMap.md#parse)
+- [ParseAnimationRanges](MeshMap.md#parseanimationranges)
 
 ## Constructors
 
 ### constructor
 
-• **new MeshMap**(`name`, `geoJson`, `projection`, `size`, `transform`, `simplification`, `depth`, `cot`, `scene?`): [`MeshMap`](MeshMap.md)
+• **new MeshMap**(`name`, `geoJson`, `projection`, `size`, `transform`, `simplification`, `depth`, `scene?`): [`MeshMap`](MeshMap.md)
 
 #### Parameters
 
@@ -42,26 +218,413 @@
 | `transform` | [`number`, `number`] |
 | `simplification` | `number` |
 | `depth` | `number` |
-| `cot` | `Nullable`\<`Node`\> |
 | `scene?` | `Scene` |
 
 #### Returns
 
 [`MeshMap`](MeshMap.md)
 
+#### Overrides
+
+TransformNode.constructor
+
 #### Defined in
 
-[prefabs/Mapping/MeshMap.ts:25](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Mapping/MeshMap.ts#L25)
+[src/prefabs/Mapping/MeshMap.ts:25](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Mapping/MeshMap.ts#L25)
 
 ## Properties
 
-### cot
+### \_accessibilityTag
 
-• **cot**: `Nullable`\<`Node`\>
+• `Protected` **\_accessibilityTag**: `IAccessibilityTag`
+
+#### Inherited from
+
+TransformNode.\_accessibilityTag
 
 #### Defined in
 
-[prefabs/Mapping/MeshMap.ts:21](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Mapping/MeshMap.ts#L21)
+node_modules/@babylonjs/core/node.d.ts:82
+
+___
+
+### \_cache
+
+• **\_cache**: `any`
+
+#### Inherited from
+
+TransformNode.\_cache
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:119
+
+___
+
+### \_childUpdateId
+
+• **\_childUpdateId**: `number`
+
+#### Inherited from
+
+TransformNode.\_childUpdateId
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:109
+
+___
+
+### \_children
+
+• `Protected` **\_children**: `Node`[]
+
+#### Inherited from
+
+TransformNode.\_children
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:122
+
+___
+
+### \_currentRenderId
+
+• **\_currentRenderId**: `number`
+
+#### Inherited from
+
+TransformNode.\_currentRenderId
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:106
+
+___
+
+### \_disposePhysicsObserver
+
+• **\_disposePhysicsObserver**: `Observer`\<`Node`\>
+
+#### Inherited from
+
+TransformNode.\_disposePhysicsObserver
+
+#### Defined in
+
+node_modules/@babylonjs/core/Physics/v2/physicsEngineComponent.d.ts:35
+
+___
+
+### \_indexInSceneTransformNodesArray
+
+• **\_indexInSceneTransformNodesArray**: `number`
+
+#### Inherited from
+
+TransformNode.\_indexInSceneTransformNodesArray
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:112
+
+___
+
+### \_internalMetadata
+
+• **\_internalMetadata**: `any`
+
+#### Inherited from
+
+TransformNode.\_internalMetadata
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:67
+
+___
+
+### \_isDirty
+
+• `Protected` **\_isDirty**: `boolean`
+
+#### Inherited from
+
+TransformNode.\_isDirty
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:24
+
+___
+
+### \_isNode
+
+• `Readonly` **\_isNode**: ``true``
+
+#### Inherited from
+
+TransformNode.\_isNode
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:160
+
+___
+
+### \_isWorldMatrixFrozen
+
+• `Protected` **\_isWorldMatrixFrozen**: `boolean`
+
+#### Inherited from
+
+TransformNode.\_isWorldMatrixFrozen
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:110
+
+___
+
+### \_localMatrix
+
+• **\_localMatrix**: `Matrix`
+
+#### Inherited from
+
+TransformNode.\_localMatrix
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:101
+
+___
+
+### \_parentContainer
+
+• **\_parentContainer**: `AbstractScene`
+
+#### Inherited from
+
+TransformNode.\_parentContainer
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:93
+
+___
+
+### \_parentNode
+
+• `Protected` **\_parentNode**: `Node`
+
+#### Inherited from
+
+TransformNode.\_parentNode
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:120
+
+___
+
+### \_physicsBody
+
+• **\_physicsBody**: `PhysicsBody`
+
+#### Inherited from
+
+TransformNode.\_physicsBody
+
+#### Defined in
+
+node_modules/@babylonjs/core/Physics/v2/physicsEngineComponent.d.ts:14
+
+___
+
+### \_poseMatrix
+
+• **\_poseMatrix**: `Matrix`
+
+#### Inherited from
+
+TransformNode.\_poseMatrix
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:99
+
+___
+
+### \_postMultiplyPivotMatrix
+
+• **\_postMultiplyPivotMatrix**: `boolean`
+
+#### Inherited from
+
+TransformNode.\_postMultiplyPivotMatrix
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:109
+
+___
+
+### \_ranges
+
+• `Protected` **\_ranges**: `Object`
+
+#### Index signature
+
+▪ [name: `string`]: `Nullable`\<`AnimationRange`\>
+
+#### Inherited from
+
+TransformNode.\_ranges
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:98
+
+___
+
+### \_scaling
+
+• `Protected` **\_scaling**: `Vector3`
+
+#### Inherited from
+
+TransformNode.\_scaling
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:52
+
+___
+
+### \_scene
+
+• **\_scene**: `Scene`
+
+#### Inherited from
+
+TransformNode.\_scene
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:117
+
+___
+
+### \_waitingParentId
+
+• **\_waitingParentId**: `string`
+
+#### Inherited from
+
+TransformNode.\_waitingParentId
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:111
+
+___
+
+### \_waitingParentInstanceIndex
+
+• **\_waitingParentInstanceIndex**: `string`
+
+#### Inherited from
+
+TransformNode.\_waitingParentInstanceIndex
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:113
+
+___
+
+### \_waitingParsedUniqueId
+
+• **\_waitingParsedUniqueId**: `number`
+
+#### Inherited from
+
+TransformNode.\_waitingParsedUniqueId
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:115
+
+___
+
+### \_worldMatrix
+
+• **\_worldMatrix**: `Matrix`
+
+#### Inherited from
+
+TransformNode.\_worldMatrix
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:124
+
+___
+
+### \_worldMatrixDeterminant
+
+• **\_worldMatrixDeterminant**: `number`
+
+#### Inherited from
+
+TransformNode.\_worldMatrixDeterminant
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:126
+
+___
+
+### \_worldMatrixDeterminantIsDirty
+
+• **\_worldMatrixDeterminantIsDirty**: `boolean`
+
+#### Inherited from
+
+TransformNode.\_worldMatrixDeterminantIsDirty
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:128
+
+___
+
+### animations
+
+• **animations**: `Animation`[]
+
+Gets a list of Animations associated with the node
+
+#### Inherited from
+
+TransformNode.animations
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:97
+
+___
+
+### cot
+
+• **cot**: `Node`
+
+#### Defined in
+
+[src/prefabs/Mapping/MeshMap.ts:21](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Mapping/MeshMap.ts#L21)
 
 ___
 
@@ -71,7 +634,7 @@ ___
 
 #### Defined in
 
-[prefabs/Mapping/MeshMap.ts:23](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Mapping/MeshMap.ts#L23)
+[src/prefabs/Mapping/MeshMap.ts:23](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Mapping/MeshMap.ts#L23)
 
 ___
 
@@ -81,7 +644,76 @@ ___
 
 #### Defined in
 
-[prefabs/Mapping/MeshMap.ts:17](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Mapping/MeshMap.ts#L17)
+[src/prefabs/Mapping/MeshMap.ts:17](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Mapping/MeshMap.ts#L17)
+
+___
+
+### id
+
+• **id**: `string`
+
+Gets or sets the id of the node
+
+#### Inherited from
+
+TransformNode.id
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:53
+
+___
+
+### ignoreNonUniformScaling
+
+• **ignoreNonUniformScaling**: `boolean`
+
+Gets or sets a boolean indicating that non uniform scaling (when at least one component is different from others) should be ignored.
+By default the system will update normals to compensate
+
+#### Inherited from
+
+TransformNode.ignoreNonUniformScaling
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:93
+
+___
+
+### inspectableCustomProperties
+
+• **inspectableCustomProperties**: `IInspectable`[]
+
+List of inspectable custom properties (used by the Inspector)
+
+**`See`**
+
+https://doc.babylonjs.com/toolsAndResources/inspector#extensibility
+
+#### Inherited from
+
+TransformNode.inspectableCustomProperties
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:76
+
+___
+
+### metadata
+
+• **metadata**: `any`
+
+Gets or sets an object used to store user defined information for the node
+
+#### Inherited from
+
+TransformNode.metadata
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:65
 
 ___
 
@@ -89,9 +721,107 @@ ___
 
 • **name**: `string`
 
+#### Overrides
+
+TransformNode.name
+
 #### Defined in
 
-[prefabs/Mapping/MeshMap.ts:14](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Mapping/MeshMap.ts#L14)
+[src/prefabs/Mapping/MeshMap.ts:14](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Mapping/MeshMap.ts#L14)
+
+___
+
+### onAccessibilityTagChangedObservable
+
+• **onAccessibilityTagChangedObservable**: `Observable`\<`IAccessibilityTag`\>
+
+Observable fired when an accessibility tag is changed
+
+#### Inherited from
+
+TransformNode.onAccessibilityTagChangedObservable
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:86
+
+___
+
+### onAfterWorldMatrixUpdateObservable
+
+• **onAfterWorldMatrixUpdateObservable**: `Observable`\<`TransformNode`\>
+
+An event triggered after the world matrix is updated
+
+#### Inherited from
+
+TransformNode.onAfterWorldMatrixUpdateObservable
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:116
+
+___
+
+### onDisposeObservable
+
+• **onDisposeObservable**: `Observable`\<`Node`\>
+
+An event triggered when the mesh is disposed
+
+#### Inherited from
+
+TransformNode.onDisposeObservable
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:164
+
+___
+
+### onReady
+
+• **onReady**: (`node`: `Node`) => `void`
+
+Callback raised when the node is ready to be used
+
+#### Type declaration
+
+▸ (`node`): `void`
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `node` | `Node` |
+
+##### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.onReady
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:104
+
+___
+
+### physicsBody
+
+• **physicsBody**: `PhysicsBody`
+
+**`See`**
+
+#### Inherited from
+
+TransformNode.physicsBody
+
+#### Defined in
+
+node_modules/@babylonjs/core/Physics/v2/physicsEngineComponent.d.ts:18
 
 ___
 
@@ -101,7 +831,55 @@ ___
 
 #### Defined in
 
-[prefabs/Mapping/MeshMap.ts:18](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Mapping/MeshMap.ts#L18)
+[src/prefabs/Mapping/MeshMap.ts:18](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Mapping/MeshMap.ts#L18)
+
+___
+
+### reIntegrateRotationIntoRotationQuaternion
+
+• **reIntegrateRotationIntoRotationQuaternion**: `boolean`
+
+Gets or sets a boolean indicating that even if rotationQuaternion is defined, you can keep updating rotation property and Babylon.js will just mix both
+
+#### Inherited from
+
+TransformNode.reIntegrateRotationIntoRotationQuaternion
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:97
+
+___
+
+### reservedDataStore
+
+• **reservedDataStore**: `any`
+
+For internal use only. Please do not use.
+
+#### Inherited from
+
+TransformNode.reservedDataStore
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:71
+
+___
+
+### scalingDeterminant
+
+• **scalingDeterminant**: `number`
+
+Multiplication factor on scale x/y/z when computing the world matrix. Eg. for a 1x1x1 cube setting this to 2 will make it a 2x2x2 cube
+
+#### Inherited from
+
+TransformNode.scalingDeterminant
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:82
 
 ___
 
@@ -111,7 +889,7 @@ ___
 
 #### Defined in
 
-[prefabs/Mapping/MeshMap.ts:15](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Mapping/MeshMap.ts#L15)
+[src/prefabs/Mapping/MeshMap.ts:15](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Mapping/MeshMap.ts#L15)
 
 ___
 
@@ -121,7 +899,7 @@ ___
 
 #### Defined in
 
-[prefabs/Mapping/MeshMap.ts:22](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Mapping/MeshMap.ts#L22)
+[src/prefabs/Mapping/MeshMap.ts:22](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Mapping/MeshMap.ts#L22)
 
 ___
 
@@ -131,7 +909,7 @@ ___
 
 #### Defined in
 
-[prefabs/Mapping/MeshMap.ts:20](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Mapping/MeshMap.ts#L20)
+[src/prefabs/Mapping/MeshMap.ts:20](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Mapping/MeshMap.ts#L20)
 
 ___
 
@@ -141,7 +919,23 @@ ___
 
 #### Defined in
 
-[prefabs/Mapping/MeshMap.ts:16](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Mapping/MeshMap.ts#L16)
+[src/prefabs/Mapping/MeshMap.ts:16](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Mapping/MeshMap.ts#L16)
+
+___
+
+### state
+
+• **state**: `string`
+
+Gets or sets a string used to store user defined state for the node
+
+#### Inherited from
+
+TransformNode.state
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:61
 
 ___
 
@@ -151,9 +945,1511 @@ ___
 
 #### Defined in
 
-[prefabs/Mapping/MeshMap.ts:19](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Mapping/MeshMap.ts#L19)
+[src/prefabs/Mapping/MeshMap.ts:19](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Mapping/MeshMap.ts#L19)
+
+___
+
+### uniqueId
+
+• **uniqueId**: `number`
+
+Gets or sets the unique id of the node
+
+#### Inherited from
+
+TransformNode.uniqueId
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:57
+
+___
+
+### BILLBOARDMODE\_ALL
+
+▪ `Static` **BILLBOARDMODE\_ALL**: `number`
+
+Object will rotate to face the camera
+
+#### Inherited from
+
+TransformNode.BILLBOARDMODE\_ALL
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:34
+
+___
+
+### BILLBOARDMODE\_NONE
+
+▪ `Static` **BILLBOARDMODE\_NONE**: `number`
+
+Object will not rotate to face the camera
+
+#### Inherited from
+
+TransformNode.BILLBOARDMODE\_NONE
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:18
+
+___
+
+### BILLBOARDMODE\_USE\_POSITION
+
+▪ `Static` **BILLBOARDMODE\_USE\_POSITION**: `number`
+
+Object will rotate to face the camera's position instead of orientation
+
+#### Inherited from
+
+TransformNode.BILLBOARDMODE\_USE\_POSITION
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:38
+
+___
+
+### BILLBOARDMODE\_X
+
+▪ `Static` **BILLBOARDMODE\_X**: `number`
+
+Object will rotate to face the camera but only on the x axis
+
+#### Inherited from
+
+TransformNode.BILLBOARDMODE\_X
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:22
+
+___
+
+### BILLBOARDMODE\_Y
+
+▪ `Static` **BILLBOARDMODE\_Y**: `number`
+
+Object will rotate to face the camera but only on the y axis
+
+#### Inherited from
+
+TransformNode.BILLBOARDMODE\_Y
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:26
+
+___
+
+### BILLBOARDMODE\_Z
+
+▪ `Static` **BILLBOARDMODE\_Z**: `number`
+
+Object will rotate to face the camera but only on the z axis
+
+#### Inherited from
+
+TransformNode.BILLBOARDMODE\_Z
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:30
+
+___
+
+### BillboardUseParentOrientation
+
+▪ `Static` **BillboardUseParentOrientation**: `boolean`
+
+Child transform with Billboard flags should or should not apply parent rotation (default if off)
+
+#### Inherited from
+
+TransformNode.BillboardUseParentOrientation
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:42
+
+___
+
+### \_AnimationRangeFactory
+
+▪ `Static` **\_AnimationRangeFactory**: (`_name`: `string`, `_from`: `number`, `_to`: `number`) => `AnimationRange`
+
+#### Type declaration
+
+▸ (`_name`, `_from`, `_to`): `AnimationRange`
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `_name` | `string` |
+| `_from` | `number` |
+| `_to` | `number` |
+
+##### Returns
+
+`AnimationRange`
+
+#### Inherited from
+
+TransformNode.\_AnimationRangeFactory
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:28
+
+## Accessors
+
+### absolutePosition
+
+• `get` **absolutePosition**(): `Vector3`
+
+Returns the current mesh absolute position.
+Returns a Vector3.
+
+#### Returns
+
+`Vector3`
+
+#### Inherited from
+
+TransformNode.absolutePosition
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:185
+
+___
+
+### absoluteRotationQuaternion
+
+• `get` **absoluteRotationQuaternion**(): `Quaternion`
+
+Returns the current mesh absolute rotation.
+Returns a Quaternion.
+
+#### Returns
+
+`Quaternion`
+
+#### Inherited from
+
+TransformNode.absoluteRotationQuaternion
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:195
+
+___
+
+### absoluteScaling
+
+• `get` **absoluteScaling**(): `Vector3`
+
+Returns the current mesh absolute scaling.
+Returns a Vector3.
+
+#### Returns
+
+`Vector3`
+
+#### Inherited from
+
+TransformNode.absoluteScaling
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:190
+
+___
+
+### accessibilityTag
+
+• `get` **accessibilityTag**(): `IAccessibilityTag`
+
+#### Returns
+
+`IAccessibilityTag`
+
+#### Inherited from
+
+TransformNode.accessibilityTag
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:81
+
+• `set` **accessibilityTag**(`value`): `void`
+
+Gets or sets the accessibility tag to describe the node for accessibility purpose.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `value` | `IAccessibilityTag` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.accessibilityTag
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:80
+
+___
+
+### animationPropertiesOverride
+
+• `get` **animationPropertiesOverride**(): `AnimationPropertiesOverride`
+
+Gets or sets the animation properties override
+
+#### Returns
+
+`AnimationPropertiesOverride`
+
+#### Inherited from
+
+TransformNode.animationPropertiesOverride
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:152
+
+• `set` **animationPropertiesOverride**(`value`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `value` | `AnimationPropertiesOverride` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.animationPropertiesOverride
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:153
+
+___
+
+### behaviors
+
+• `get` **behaviors**(): `Behavior`\<`Node`\>[]
+
+Gets the list of attached behaviors
+
+#### Returns
+
+`Behavior`\<`Node`\>[]
+
+**`See`**
+
+https://doc.babylonjs.com/features/featuresDeepDive/behaviors
+
+#### Inherited from
+
+TransformNode.behaviors
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:215
+
+___
+
+### billboardMode
+
+• `get` **billboardMode**(): `number`
+
+Gets or sets the billboard mode. Default is 0.
+
+| Value | Type | Description |
+| --- | --- | --- |
+| 0 | BILLBOARDMODE_NONE |  |
+| 1 | BILLBOARDMODE_X |  |
+| 2 | BILLBOARDMODE_Y |  |
+| 4 | BILLBOARDMODE_Z |  |
+| 7 | BILLBOARDMODE_ALL |  |
+
+#### Returns
+
+`number`
+
+#### Inherited from
+
+TransformNode.billboardMode
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:69
+
+• `set` **billboardMode**(`value`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `value` | `number` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.billboardMode
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:70
+
+___
+
+### doNotSerialize
+
+• `get` **doNotSerialize**(): `boolean`
+
+Gets or sets a boolean used to define if the node must be serialized
+
+#### Returns
+
+`boolean`
+
+#### Inherited from
+
+TransformNode.doNotSerialize
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:90
+
+• `set` **doNotSerialize**(`value`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `value` | `boolean` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.doNotSerialize
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:91
+
+___
+
+### forward
+
+• `get` **forward**(): `Vector3`
+
+The forward direction of that transform in world space.
+
+#### Returns
+
+`Vector3`
+
+#### Inherited from
+
+TransformNode.forward
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:157
+
+___
+
+### infiniteDistance
+
+• `get` **infiniteDistance**(): `boolean`
+
+Gets or sets the distance of the object to max, often used by skybox
+
+#### Returns
+
+`boolean`
+
+#### Inherited from
+
+TransformNode.infiniteDistance
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:87
+
+• `set` **infiniteDistance**(`value`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `value` | `boolean` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.infiniteDistance
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:88
+
+___
+
+### isWorldMatrixFrozen
+
+• `get` **isWorldMatrixFrozen**(): `boolean`
+
+True if the World matrix has been frozen.
+
+#### Returns
+
+`boolean`
+
+#### Inherited from
+
+TransformNode.isWorldMatrixFrozen
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:241
+
+___
+
+### nonUniformScaling
+
+• `get` **nonUniformScaling**(): `boolean`
+
+True if the scaling property of this object is non uniform eg. (1,2,1)
+
+#### Returns
+
+`boolean`
+
+#### Inherited from
+
+TransformNode.nonUniformScaling
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:372
+
+___
+
+### onClonedObservable
+
+• `get` **onClonedObservable**(): `Observable`\<`Node`\>
+
+An event triggered when the node is cloned
+
+#### Returns
+
+`Observable`\<`Node`\>
+
+#### Inherited from
+
+TransformNode.onClonedObservable
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:177
+
+___
+
+### onDispose
+
+• `set` **onDispose**(`callback`): `void`
+
+Sets a callback that will be raised when the node will be disposed
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `callback` | () => `void` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.onDispose
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:169
+
+___
+
+### onEnabledStateChangedObservable
+
+• `get` **onEnabledStateChangedObservable**(): `Observable`\<`boolean`\>
+
+An event triggered when the enabled state of the node changes
+
+#### Returns
+
+`Observable`\<`boolean`\>
+
+#### Inherited from
+
+TransformNode.onEnabledStateChangedObservable
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:173
+
+___
+
+### parent
+
+• `get` **parent**(): `Node`
+
+#### Returns
+
+`Node`
+
+#### Inherited from
+
+TransformNode.parent
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:139
+
+• `set` **parent**(`parent`): `void`
+
+Gets or sets the parent of the node (without keeping the current position in the scene)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `parent` | `Node` |
+
+#### Returns
+
+`void`
+
+**`See`**
+
+https://doc.babylonjs.com/features/featuresDeepDive/mesh/transforms/parent_pivot/parent
+
+#### Inherited from
+
+TransformNode.parent
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:138
+
+___
+
+### position
+
+• `get` **position**(): `Vector3`
+
+Gets or set the node position (default is (0.0, 0.0, 0.0))
+
+#### Returns
+
+`Vector3`
+
+#### Inherited from
+
+TransformNode.position
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:126
+
+• `set` **position**(`newPosition`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `newPosition` | `Vector3` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.position
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:127
+
+___
+
+### preserveParentRotationForBillboard
+
+• `get` **preserveParentRotationForBillboard**(): `boolean`
+
+Gets or sets a boolean indicating that parent rotation should be preserved when using billboards.
+This could be useful for glTF objects where parent rotation helps converting from right handed to left handed
+
+#### Returns
+
+`boolean`
+
+#### Inherited from
+
+TransformNode.preserveParentRotationForBillboard
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:76
+
+• `set` **preserveParentRotationForBillboard**(`value`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `value` | `boolean` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.preserveParentRotationForBillboard
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:77
+
+___
+
+### right
+
+• `get` **right**(): `Vector3`
+
+The right direction of that transform in world space.
+
+#### Returns
+
+`Vector3`
+
+#### Inherited from
+
+TransformNode.right
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:165
+
+___
+
+### rotation
+
+• `get` **rotation**(): `Vector3`
+
+Gets or sets the rotation property : a Vector3 defining the rotation value in radians around each local axis X, Y, Z  (default is (0.0, 0.0, 0.0)).
+If rotation quaternion is set, this Vector3 will be ignored and copy from the quaternion
+
+#### Returns
+
+`Vector3`
+
+#### Inherited from
+
+TransformNode.rotation
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:141
+
+• `set` **rotation**(`newRotation`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `newRotation` | `Vector3` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.rotation
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:142
+
+___
+
+### rotationQuaternion
+
+• `get` **rotationQuaternion**(): `Quaternion`
+
+Gets or sets the rotation Quaternion property : this a Quaternion object defining the node rotation by using a unit quaternion (undefined by default, but can be null).
+If set, only the rotationQuaternion is then used to compute the node rotation (ie. node.rotation will be ignored)
+
+#### Returns
+
+`Quaternion`
+
+#### Inherited from
+
+TransformNode.rotationQuaternion
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:152
+
+• `set` **rotationQuaternion**(`quaternion`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `quaternion` | `Quaternion` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.rotationQuaternion
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:153
+
+___
+
+### scaling
+
+• `get` **scaling**(): `Vector3`
+
+Gets or sets the scaling property : a Vector3 defining the node scaling along each local axis X, Y, Z (default is (1.0, 1.0, 1.0)).
+
+#### Returns
+
+`Vector3`
+
+#### Inherited from
+
+TransformNode.scaling
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:146
+
+• `set` **scaling**(`newScaling`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `newScaling` | `Vector3` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.scaling
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:147
+
+___
+
+### up
+
+• `get` **up**(): `Vector3`
+
+The up direction of that transform in world space.
+
+#### Returns
+
+`Vector3`
+
+#### Inherited from
+
+TransformNode.up
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:161
+
+___
+
+### worldMatrixFromCache
+
+• `get` **worldMatrixFromCache**(): `Matrix`
+
+Returns directly the latest state of the mesh World matrix.
+A Matrix is returned.
+
+#### Returns
+
+`Matrix`
+
+#### Inherited from
+
+TransformNode.worldMatrixFromCache
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:234
 
 ## Methods
+
+### \_addToSceneRootNodes
+
+▸ **_addToSceneRootNodes**(): `void`
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.\_addToSceneRootNodes
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:145
+
+___
+
+### \_afterComputeWorldMatrix
+
+▸ **_afterComputeWorldMatrix**(): `void`
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.\_afterComputeWorldMatrix
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:462
+
+___
+
+### \_getActionManagerForTrigger
+
+▸ **_getActionManagerForTrigger**(`trigger?`, `_initialCall?`): `AbstractActionManager`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `trigger?` | `number` |
+| `_initialCall?` | `boolean` |
+
+#### Returns
+
+`AbstractActionManager`
+
+#### Inherited from
+
+TransformNode.\_getActionManagerForTrigger
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:244
+
+___
+
+### \_getDescendants
+
+▸ **_getDescendants**(`results`, `directDescendantsOnly?`, `predicate?`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `results` | `Node`[] |
+| `directDescendantsOnly?` | `boolean` |
+| `predicate?` | (`node`: `Node`) => `boolean` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.\_getDescendants
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:293
+
+___
+
+### \_getEffectiveParent
+
+▸ **_getEffectiveParent**(): `Node`
+
+#### Returns
+
+`Node`
+
+#### Inherited from
+
+TransformNode.\_getEffectiveParent
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:443
+
+___
+
+### \_getWorldMatrixDeterminant
+
+▸ **_getWorldMatrixDeterminant**(): `number`
+
+#### Returns
+
+`number`
+
+#### Inherited from
+
+TransformNode.\_getWorldMatrixDeterminant
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:229
+
+___
+
+### \_initCache
+
+▸ **_initCache**(): `void`
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.\_initCache
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:180
+
+___
+
+### \_isSynchronized
+
+▸ **_isSynchronized**(): `boolean`
+
+#### Returns
+
+`boolean`
+
+#### Inherited from
+
+TransformNode.\_isSynchronized
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:178
+
+___
+
+### \_markSyncedWithParent
+
+▸ **_markSyncedWithParent**(): `void`
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.\_markSyncedWithParent
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:252
+
+___
+
+### \_removeFromSceneRootNodes
+
+▸ **_removeFromSceneRootNodes**(): `void`
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.\_removeFromSceneRootNodes
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:147
+
+___
+
+### \_serializeAsParent
+
+▸ **_serializeAsParent**(`serializationObject`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `serializationObject` | `any` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.\_serializeAsParent
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:143
+
+___
+
+### \_setReady
+
+▸ **_setReady**(`state`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `state` | `boolean` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.\_setReady
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:339
+
+___
+
+### \_syncParentEnabledState
+
+▸ **_syncParentEnabledState**(): `void`
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.\_syncParentEnabledState
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:277
+
+___
+
+### \_updateCache
+
+▸ **_updateCache**(`_ignoreParentClass?`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `_ignoreParentClass?` | `boolean` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.\_updateCache
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:248
+
+___
+
+### \_updateNonUniformScalingState
+
+▸ **_updateNonUniformScalingState**(`value`): `boolean`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `value` | `boolean` |
+
+#### Returns
+
+`boolean`
+
+#### Inherited from
+
+TransformNode.\_updateNonUniformScalingState
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:376
+
+___
+
+### addBehavior
+
+▸ **addBehavior**(`behavior`, `attachImmediately?`): `Node`
+
+Attach a behavior to the node
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `behavior` | `Behavior`\<`Node`\> | defines the behavior to attach |
+| `attachImmediately?` | `boolean` | defines that the behavior must be attached even if the scene is still loading |
+
+#### Returns
+
+`Node`
+
+the current Node
+
+**`See`**
+
+https://doc.babylonjs.com/features/featuresDeepDive/behaviors
+
+#### Inherited from
+
+TransformNode.addBehavior
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:203
+
+___
+
+### addChild
+
+▸ **addChild**(`mesh`, `preserveScalingSign?`): `this`
+
+Adds the passed mesh as a child to the current mesh
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `mesh` | `TransformNode` | defines the child mesh |
+| `preserveScalingSign?` | `boolean` | if true, keep scaling sign of child. Otherwise, scaling sign might change. |
+
+#### Returns
+
+`this`
+
+the current mesh
+
+#### Inherited from
+
+TransformNode.addChild
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:360
+
+___
+
+### addRotation
+
+▸ **addRotation**(`x`, `y`, `z`): `TransformNode`
+
+Adds a rotation step to the mesh current rotation.
+x, y, z are Euler angles expressed in radians.
+This methods updates the current mesh rotation, either mesh.rotation, either mesh.rotationQuaternion if it's set.
+This means this rotation is made in the mesh local space only.
+It's useful to set a custom rotation order different from the BJS standard one YXZ.
+Example : this rotates the mesh first around its local X axis, then around its local Z axis, finally around its local Y axis.
+```javascript
+mesh.addRotation(x1, 0, 0).addRotation(0, 0, z2).addRotation(0, 0, y3);
+```
+Note that `addRotation()` accumulates the passed rotation values to the current ones and computes the .rotation or .rotationQuaternion updated values.
+Under the hood, only quaternions are used. So it's a little faster is you use .rotationQuaternion because it doesn't need to translate them back to Euler angles.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `x` | `number` | Rotation to add |
+| `y` | `number` | Rotation to add |
+| `z` | `number` | Rotation to add |
+
+#### Returns
+
+`TransformNode`
+
+the TransformNode.
+
+#### Inherited from
+
+TransformNode.addRotation
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:439
+
+___
+
+### applyAngularImpulse
+
+▸ **applyAngularImpulse**(`angularImpulse`): `TransformNode`
+
+Apply a physic angular impulse to the mesh
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `angularImpulse` | `Vector3` | defines the torque to apply |
+
+#### Returns
+
+`TransformNode`
+
+the current mesh
+
+#### Inherited from
+
+TransformNode.applyAngularImpulse
+
+#### Defined in
+
+node_modules/@babylonjs/core/Physics/v2/physicsEngineComponent.d.ts:33
+
+___
+
+### applyImpulse
+
+▸ **applyImpulse**(`force`, `contactPoint`): `TransformNode`
+
+Apply a physic impulse to the mesh
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `force` | `Vector3` | defines the force to apply |
+| `contactPoint` | `Vector3` | defines where to apply the force |
+
+#### Returns
+
+`TransformNode`
+
+the current mesh
+
+#### Inherited from
+
+TransformNode.applyImpulse
+
+#### Defined in
+
+node_modules/@babylonjs/core/Physics/v2/physicsEngineComponent.d.ts:28
+
+___
+
+### attachToBone
+
+▸ **attachToBone**(`bone`, `affectedTransformNode`): `TransformNode`
+
+Attach the current TransformNode to another TransformNode associated with a bone
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `bone` | `Bone` | Bone affecting the TransformNode |
+| `affectedTransformNode` | `TransformNode` | TransformNode associated with the bone |
+
+#### Returns
+
+`TransformNode`
+
+this object
+
+#### Inherited from
+
+TransformNode.attachToBone
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:383
+
+___
+
+### beginAnimation
+
+▸ **beginAnimation**(`name`, `loop?`, `speedRatio?`, `onAnimationEnd?`): `Animatable`
+
+Will start the animation sequence
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `name` | `string` | defines the range frames for animation sequence |
+| `loop?` | `boolean` | defines if the animation should loop (false by default) |
+| `speedRatio?` | `number` | defines the speed factor in which to run the animation (1 by default) |
+| `onAnimationEnd?` | () => `void` | defines a function to be executed when the animation ended (undefined by default) |
+
+#### Returns
+
+`Animatable`
+
+the object created for this animation. If range does not exist, it will return null
+
+#### Inherited from
+
+TransformNode.beginAnimation
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:386
+
+___
+
+### clone
+
+▸ **clone**(`name`, `newParent`, `doNotCloneChildren?`): `TransformNode`
+
+Clone the current transform node
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `name` | `string` | Name of the new clone |
+| `newParent` | `Node` | New parent for the clone |
+| `doNotCloneChildren?` | `boolean` | Do not clone children hierarchy |
+
+#### Returns
+
+`TransformNode`
+
+the new transform node
+
+#### Inherited from
+
+TransformNode.clone
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:495
+
+___
+
+### computeWorldMatrix
+
+▸ **computeWorldMatrix**(`force?`, `camera?`): `Matrix`
+
+Computes the world matrix of the node
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `force?` | `boolean` | defines if the cache version should be invalidated forcing the world matrix to be created from scratch |
+| `camera?` | `Camera` | defines the camera used if different from the scene active camera (This is used with modes like Billboard or infinite distance) |
+
+#### Returns
+
+`Matrix`
+
+the world matrix
+
+#### Inherited from
+
+TransformNode.computeWorldMatrix
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:456
+
+___
+
+### createAnimationRange
+
+▸ **createAnimationRange**(`name`, `from`, `to`): `void`
+
+Creates an animation range for this node
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `name` | `string` | defines the name of the range |
+| `from` | `number` | defines the starting key |
+| `to` | `number` | defines the end key |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.createAnimationRange
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:352
+
+___
 
 ### createMap
 
@@ -165,4 +2461,1960 @@ ___
 
 #### Defined in
 
-[prefabs/Mapping/MeshMap.ts:38](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Mapping/MeshMap.ts#L38)
+[src/prefabs/Mapping/MeshMap.ts:37](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Mapping/MeshMap.ts#L37)
+
+___
+
+### deleteAnimationRange
+
+▸ **deleteAnimationRange**(`name`, `deleteFrames?`): `void`
+
+Delete a specific animation range
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `name` | `string` | defines the name of the range to delete |
+| `deleteFrames?` | `boolean` | defines if animation frames from the range must be deleted as well |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.deleteAnimationRange
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:358
+
+___
+
+### detachFromBone
+
+▸ **detachFromBone**(`resetToPreviousParent?`): `TransformNode`
+
+Detach the transform node if its associated with a bone
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `resetToPreviousParent?` | `boolean` | Indicates if the parent that was in effect when attachToBone was called should be set back or if we should set parent to null instead (defaults to the latter) |
+
+#### Returns
+
+`TransformNode`
+
+this object
+
+#### Inherited from
+
+TransformNode.detachFromBone
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:389
+
+___
+
+### dispose
+
+▸ **dispose**(`doNotRecurse?`, `disposeMaterialAndTextures?`): `void`
+
+Releases resources associated with this transform node.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `doNotRecurse?` | `boolean` | Set to true to not recurse into each children (recurse into each children by default) |
+| `disposeMaterialAndTextures?` | `boolean` | Set to true to also dispose referenced materials and textures (false by default) |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.dispose
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:522
+
+___
+
+### freezeWorldMatrix
+
+▸ **freezeWorldMatrix**(`newWorldMatrix?`, `decompose?`): `TransformNode`
+
+Prevents the World matrix to be computed any longer
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `newWorldMatrix?` | `Matrix` | defines an optional matrix to use as world matrix |
+| `decompose?` | `boolean` | defines whether to decompose the given newWorldMatrix or directly assign |
+
+#### Returns
+
+`TransformNode`
+
+the TransformNode.
+
+#### Inherited from
+
+TransformNode.freezeWorldMatrix
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:232
+
+___
+
+### getAbsolutePivotPoint
+
+▸ **getAbsolutePivotPoint**(): `Vector3`
+
+Returns a new Vector3 set with the mesh pivot point World coordinates.
+
+#### Returns
+
+`Vector3`
+
+a new Vector3 set with the mesh pivot point World coordinates.
+
+#### Inherited from
+
+TransformNode.getAbsolutePivotPoint
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:328
+
+___
+
+### getAbsolutePivotPointToRef
+
+▸ **getAbsolutePivotPointToRef**(`result`): `TransformNode`
+
+Sets the Vector3 "result" coordinates with the mesh pivot point World coordinates.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `result` | `Vector3` | vector3 to store the result |
+
+#### Returns
+
+`TransformNode`
+
+this TransformNode.
+
+#### Inherited from
+
+TransformNode.getAbsolutePivotPointToRef
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:334
+
+___
+
+### getAbsolutePosition
+
+▸ **getAbsolutePosition**(): `Vector3`
+
+Returns the mesh absolute position in the World.
+
+#### Returns
+
+`Vector3`
+
+a Vector3.
+
+#### Inherited from
+
+TransformNode.getAbsolutePosition
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:246
+
+___
+
+### getAnimationByName
+
+▸ **getAnimationByName**(`name`): `Animation`
+
+Get an animation by name
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `name` | `string` | defines the name of the animation to look for |
+
+#### Returns
+
+`Animation`
+
+null if not found else the requested animation
+
+#### Inherited from
+
+TransformNode.getAnimationByName
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:345
+
+___
+
+### getAnimationRange
+
+▸ **getAnimationRange**(`name`): `AnimationRange`
+
+Get an animation range by name
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `name` | `string` | defines the name of the animation range to look for |
+
+#### Returns
+
+`AnimationRange`
+
+null if not found else the requested animation range
+
+#### Inherited from
+
+TransformNode.getAnimationRange
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:364
+
+___
+
+### getAnimationRanges
+
+▸ **getAnimationRanges**(): `AnimationRange`[]
+
+Gets the list of all animation ranges defined on this node
+
+#### Returns
+
+`AnimationRange`[]
+
+an array
+
+#### Inherited from
+
+TransformNode.getAnimationRanges
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:377
+
+___
+
+### getBehaviorByName
+
+▸ **getBehaviorByName**(`name`): `Behavior`\<`Node`\>
+
+Gets an attached behavior by name
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `name` | `string` | defines the name of the behavior to look for |
+
+#### Returns
+
+`Behavior`\<`Node`\>
+
+null if behavior was not found else the requested behavior
+
+**`See`**
+
+https://doc.babylonjs.com/features/featuresDeepDive/behaviors
+
+#### Inherited from
+
+TransformNode.getBehaviorByName
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:222
+
+___
+
+### getChildMeshes
+
+▸ **getChildMeshes**\<`T`\>(`directDescendantsOnly?`, `predicate?`): `T`[]
+
+Get all child-meshes of this node
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `AbstractMesh` |
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `directDescendantsOnly?` | `boolean` | defines if true only direct descendants of 'this' will be considered, if false direct and also indirect (children of children, an so on in a recursive manner) descendants of 'this' will be considered (Default: false) |
+| `predicate?` | (`node`: `Node`) => node is T | defines an optional predicate that will be called on every evaluated child, the predicate must return true for a given child to be part of the result, otherwise it will be ignored |
+
+#### Returns
+
+`T`[]
+
+an array of AbstractMesh
+
+#### Inherited from
+
+TransformNode.getChildMeshes
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:314
+
+▸ **getChildMeshes**(`directDescendantsOnly?`, `predicate?`): `AbstractMesh`[]
+
+Get all child-meshes of this node
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `directDescendantsOnly?` | `boolean` | defines if true only direct descendants of 'this' will be considered, if false direct and also indirect (children of children, an so on in a recursive manner) descendants of 'this' will be considered (Default: false) |
+| `predicate?` | (`node`: `Node`) => `boolean` | defines an optional predicate that will be called on every evaluated child, the predicate must return true for a given child to be part of the result, otherwise it will be ignored |
+
+#### Returns
+
+`AbstractMesh`[]
+
+an array of AbstractMesh
+
+#### Inherited from
+
+TransformNode.getChildMeshes
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:321
+
+___
+
+### getChildTransformNodes
+
+▸ **getChildTransformNodes**(`directDescendantsOnly?`, `predicate?`): `TransformNode`[]
+
+Get all child-transformNodes of this node
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `directDescendantsOnly?` | `boolean` | defines if true only direct descendants of 'this' will be considered, if false direct and also indirect (children of children, an so on in a recursive manner) descendants of 'this' will be considered |
+| `predicate?` | (`node`: `Node`) => `boolean` | defines an optional predicate that will be called on every evaluated child, the predicate must return true for a given child to be part of the result, otherwise it will be ignored |
+
+#### Returns
+
+`TransformNode`[]
+
+an array of TransformNode
+
+#### Inherited from
+
+TransformNode.getChildTransformNodes
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:516
+
+___
+
+### getChildren
+
+▸ **getChildren**\<`T`\>(`predicate?`, `directDescendantsOnly?`): `T`[]
+
+Get all direct children of this node
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `Node` |
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `predicate?` | (`node`: `Node`) => node is T | defines an optional predicate that will be called on every evaluated child, the predicate must return true for a given child to be part of the result, otherwise it will be ignored |
+| `directDescendantsOnly?` | `boolean` | defines if true only direct descendants of 'this' will be considered, if false direct and also indirect (children of children, an so on in a recursive manner) descendants of 'this' will be considered (Default: true) |
+
+#### Returns
+
+`T`[]
+
+an array of Node
+
+#### Inherited from
+
+TransformNode.getChildren
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:328
+
+▸ **getChildren**(`predicate?`, `directDescendantsOnly?`): `Node`[]
+
+Get all direct children of this node
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `predicate?` | (`node`: `Node`) => `boolean` | defines an optional predicate that will be called on every evaluated child, the predicate must return true for a given child to be part of the result, otherwise it will be ignored |
+| `directDescendantsOnly?` | `boolean` | defines if true only direct descendants of 'this' will be considered, if false direct and also indirect (children of children, an so on in a recursive manner) descendants of 'this' will be considered (Default: true) |
+
+#### Returns
+
+`Node`[]
+
+an array of Node
+
+#### Inherited from
+
+TransformNode.getChildren
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:335
+
+___
+
+### getClassName
+
+▸ **getClassName**(): `string`
+
+Gets a string identifying the name of the class
+
+#### Returns
+
+`string`
+
+"TransformNode" string
+
+#### Inherited from
+
+TransformNode.getClassName
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:122
+
+___
+
+### getDescendants
+
+▸ **getDescendants**\<`T`\>(`directDescendantsOnly?`, `predicate?`): `T`[]
+
+Will return all nodes that have this node as ascendant
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `Node` |
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `directDescendantsOnly?` | `boolean` | defines if true only direct descendants of 'this' will be considered, if false direct and also indirect (children of children, an so on in a recursive manner) descendants of 'this' will be considered |
+| `predicate?` | (`node`: `Node`) => node is T | defines an optional predicate that will be called on every evaluated child, the predicate must return true for a given child to be part of the result, otherwise it will be ignored |
+
+#### Returns
+
+`T`[]
+
+all children nodes of all types
+
+#### Inherited from
+
+TransformNode.getDescendants
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:300
+
+▸ **getDescendants**(`directDescendantsOnly?`, `predicate?`): `Node`[]
+
+Will return all nodes that have this node as ascendant
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `directDescendantsOnly?` | `boolean` | defines if true only direct descendants of 'this' will be considered, if false direct and also indirect (children of children, an so on in a recursive manner) descendants of 'this' will be considered |
+| `predicate?` | (`node`: `Node`) => `boolean` | defines an optional predicate that will be called on every evaluated child, the predicate must return true for a given child to be part of the result, otherwise it will be ignored |
+
+#### Returns
+
+`Node`[]
+
+all children nodes of all types
+
+#### Inherited from
+
+TransformNode.getDescendants
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:307
+
+___
+
+### getDirection
+
+▸ **getDirection**(`localAxis`): `Vector3`
+
+Returns a new Vector3 that is the localAxis, expressed in the mesh local space, rotated like the mesh.
+This Vector3 is expressed in the World space.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `localAxis` | `Vector3` | axis to rotate |
+
+#### Returns
+
+`Vector3`
+
+a new Vector3 that is the localAxis, expressed in the mesh local space, rotated like the mesh.
+
+#### Inherited from
+
+TransformNode.getDirection
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:287
+
+___
+
+### getDirectionToRef
+
+▸ **getDirectionToRef**(`localAxis`, `result`): `TransformNode`
+
+Sets the Vector3 "result" as the rotated Vector3 "localAxis" in the same rotation than the mesh.
+localAxis is expressed in the mesh local space.
+result is computed in the World space from the mesh World matrix.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `localAxis` | `Vector3` | axis to rotate |
+| `result` | `Vector3` | the resulting transformnode |
+
+#### Returns
+
+`TransformNode`
+
+this TransformNode.
+
+#### Inherited from
+
+TransformNode.getDirectionToRef
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:296
+
+___
+
+### getDistanceToCamera
+
+▸ **getDistanceToCamera**(`camera?`): `number`
+
+Returns the distance from the mesh to the active camera
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `camera?` | `Camera` | defines the camera to use |
+
+#### Returns
+
+`number`
+
+the distance
+
+#### Inherited from
+
+TransformNode.getDistanceToCamera
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:487
+
+___
+
+### getEngine
+
+▸ **getEngine**(): `AbstractEngine`
+
+Gets the engine of the node
+
+#### Returns
+
+`AbstractEngine`
+
+a Engine
+
+#### Inherited from
+
+TransformNode.getEngine
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:194
+
+___
+
+### getHierarchyBoundingVectors
+
+▸ **getHierarchyBoundingVectors**(`includeDescendants?`, `predicate?`): `Object`
+
+Return the minimum and maximum world vectors of the entire hierarchy under current node
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `includeDescendants?` | `boolean` | Include bounding info from descendants as well (true by default) |
+| `predicate?` | (`abstractMesh`: `AbstractMesh`) => `boolean` | defines a callback function that can be customize to filter what meshes should be included in the list used to compute the bounding vectors |
+
+#### Returns
+
+`Object`
+
+the new bounding vectors
+
+| Name | Type |
+| :------ | :------ |
+| `max` | `Vector3` |
+| `min` | `Vector3` |
+
+#### Inherited from
+
+TransformNode.getHierarchyBoundingVectors
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:417
+
+___
+
+### getPhysicsBody
+
+▸ **getPhysicsBody**(): `PhysicsBody`
+
+#### Returns
+
+`PhysicsBody`
+
+#### Inherited from
+
+TransformNode.getPhysicsBody
+
+#### Defined in
+
+node_modules/@babylonjs/core/Physics/v2/physicsEngineComponent.d.ts:22
+
+___
+
+### getPivotMatrix
+
+▸ **getPivotMatrix**(): `Matrix`
+
+Returns the mesh pivot matrix.
+Default : Identity.
+
+#### Returns
+
+`Matrix`
+
+the matrix
+
+#### Inherited from
+
+TransformNode.getPivotMatrix
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:214
+
+___
+
+### getPivotPoint
+
+▸ **getPivotPoint**(): `Vector3`
+
+Returns a new Vector3 set with the mesh pivot point coordinates in the local space.
+
+#### Returns
+
+`Vector3`
+
+the pivot point
+
+#### Inherited from
+
+TransformNode.getPivotPoint
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:317
+
+___
+
+### getPivotPointToRef
+
+▸ **getPivotPointToRef**(`result`): `TransformNode`
+
+Sets the passed Vector3 "result" with the coordinates of the mesh pivot point in the local space.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `result` | `Vector3` | the vector3 to store the result |
+
+#### Returns
+
+`TransformNode`
+
+this TransformNode.
+
+#### Inherited from
+
+TransformNode.getPivotPointToRef
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:323
+
+___
+
+### getPoseMatrix
+
+▸ **getPoseMatrix**(): `Matrix`
+
+Returns the mesh Pose matrix.
+
+#### Returns
+
+`Matrix`
+
+the pose matrix
+
+#### Inherited from
+
+TransformNode.getPoseMatrix
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:176
+
+___
+
+### getPositionExpressedInLocalSpace
+
+▸ **getPositionExpressedInLocalSpace**(): `Vector3`
+
+Returns the mesh position in the local space from the current World matrix values.
+
+#### Returns
+
+`Vector3`
+
+a new Vector3.
+
+#### Inherited from
+
+TransformNode.getPositionExpressedInLocalSpace
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:263
+
+___
+
+### getPositionInCameraSpace
+
+▸ **getPositionInCameraSpace**(`camera?`): `Vector3`
+
+Gets the position of the current mesh in camera space
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `camera?` | `Camera` | defines the camera to use |
+
+#### Returns
+
+`Vector3`
+
+a position
+
+#### Inherited from
+
+TransformNode.getPositionInCameraSpace
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:481
+
+___
+
+### getScene
+
+▸ **getScene**(): `Scene`
+
+Gets the scene of the node
+
+#### Returns
+
+`Scene`
+
+a scene
+
+#### Inherited from
+
+TransformNode.getScene
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:189
+
+___
+
+### getWorldMatrix
+
+▸ **getWorldMatrix**(): `Matrix`
+
+Returns the latest update of the World matrix
+
+#### Returns
+
+`Matrix`
+
+a Matrix
+
+#### Inherited from
+
+TransformNode.getWorldMatrix
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:227
+
+___
+
+### instantiateHierarchy
+
+▸ **instantiateHierarchy**(`newParent?`, `options?`, `onNewNodeCreated?`): `TransformNode`
+
+Instantiate (when possible) or clone that node with its hierarchy
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `newParent?` | `TransformNode` | defines the new parent to use for the instance (or clone) |
+| `options?` | `Object` | defines options to configure how copy is done |
+| `options.doNotInstantiate` | `boolean` \| (`node`: `TransformNode`) => `boolean` | defines if the model must be instantiated or just cloned |
+| `onNewNodeCreated?` | (`source`: `TransformNode`, `clone`: `TransformNode`) => `void` | defines an option callback to call when a clone or an instance is created |
+
+#### Returns
+
+`TransformNode`
+
+an instance (or a clone) of the current node with its hierarchy
+
+#### Inherited from
+
+TransformNode.instantiateHierarchy
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:223
+
+___
+
+### isDescendantOf
+
+▸ **isDescendantOf**(`ancestor`): `boolean`
+
+Is this node a descendant of the given node?
+The function will iterate up the hierarchy until the ancestor was found or no more parents defined
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `ancestor` | `Node` | defines the parent node to inspect |
+
+#### Returns
+
+`boolean`
+
+a boolean indicating if this node is a descendant of the given node
+
+#### Inherited from
+
+TransformNode.isDescendantOf
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:289
+
+___
+
+### isDisposed
+
+▸ **isDisposed**(): `boolean`
+
+Gets a boolean indicating if the node has been disposed
+
+#### Returns
+
+`boolean`
+
+true if the node was disposed
+
+#### Inherited from
+
+TransformNode.isDisposed
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:133
+
+___
+
+### isEnabled
+
+▸ **isEnabled**(`checkAncestors?`): `boolean`
+
+Is this node enabled?
+If the node has a parent, all ancestors will be checked and false will be returned if any are false (not enabled), otherwise will return true
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `checkAncestors?` | `boolean` | indicates if this method should check the ancestors. The default is to check the ancestors. If set to false, the method will return the value of this node without checking ancestors |
+
+#### Returns
+
+`boolean`
+
+whether this node (and its parent) is enabled
+
+#### Inherited from
+
+TransformNode.isEnabled
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:275
+
+___
+
+### isReady
+
+▸ **isReady**(`_completeCheck?`): `boolean`
+
+Is this node ready to be used/rendered
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `_completeCheck?` | `boolean` | defines if a complete check (including materials and lights) has to be done (false by default) |
+
+#### Returns
+
+`boolean`
+
+true if the node is ready
+
+#### Inherited from
+
+TransformNode.isReady
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:262
+
+___
+
+### isSynchronized
+
+▸ **isSynchronized**(): `boolean`
+
+#### Returns
+
+`boolean`
+
+#### Inherited from
+
+TransformNode.isSynchronized
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:256
+
+___
+
+### isSynchronizedWithParent
+
+▸ **isSynchronizedWithParent**(): `boolean`
+
+#### Returns
+
+`boolean`
+
+#### Inherited from
+
+TransformNode.isSynchronizedWithParent
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:254
+
+___
+
+### isUsingPivotMatrix
+
+▸ **isUsingPivotMatrix**(): `boolean`
+
+return true if a pivot has been set
+
+#### Returns
+
+`boolean`
+
+true if a pivot matrix is used
+
+#### Inherited from
+
+TransformNode.isUsingPivotMatrix
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:132
+
+___
+
+### isUsingPostMultiplyPivotMatrix
+
+▸ **isUsingPostMultiplyPivotMatrix**(): `boolean`
+
+#### Returns
+
+`boolean`
+
+true if pivot matrix must be cancelled in the world matrix. When this parameter is set to true (default), the inverse of the pivot matrix is also applied at the end to cancel the transformation effect.
+
+#### Inherited from
+
+TransformNode.isUsingPostMultiplyPivotMatrix
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:136
+
+___
+
+### isWorldMatrixCameraDependent
+
+▸ **isWorldMatrixCameraDependent**(): `boolean`
+
+Returns whether the transform node world matrix computation needs the camera information to be computed.
+This is the case when the node is a billboard or has an infinite distance for instance.
+
+#### Returns
+
+`boolean`
+
+true if the world matrix computation needs the camera information to be computed
+
+#### Inherited from
+
+TransformNode.isWorldMatrixCameraDependent
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:449
+
+___
+
+### locallyTranslate
+
+▸ **locallyTranslate**(`vector3`): `TransformNode`
+
+Translates the mesh along the passed Vector3 in its local space.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `vector3` | `Vector3` | the distance to translate in localspace |
+
+#### Returns
+
+`TransformNode`
+
+the TransformNode.
+
+#### Inherited from
+
+TransformNode.locallyTranslate
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:269
+
+___
+
+### lookAt
+
+▸ **lookAt**(`targetPoint`, `yawCor?`, `pitchCor?`, `rollCor?`, `space?`): `TransformNode`
+
+Orients a mesh towards a target point. Mesh must be drawn facing user.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `targetPoint` | `Vector3` | the position (must be in same space as current mesh) to look at |
+| `yawCor?` | `number` | optional yaw (y-axis) correction in radians |
+| `pitchCor?` | `number` | optional pitch (x-axis) correction in radians |
+| `rollCor?` | `number` | optional roll (z-axis) correction in radians |
+| `space?` | `Space` | the chosen space of the target |
+
+#### Returns
+
+`TransformNode`
+
+the TransformNode.
+
+#### Inherited from
+
+TransformNode.lookAt
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:280
+
+___
+
+### markAsDirty
+
+▸ **markAsDirty**(`property?`): `Node`
+
+Flag the transform node as dirty (Forcing it to update everything)
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `property?` | `string` | if set to "rotation" the objects rotationQuaternion will be set to null |
+
+#### Returns
+
+`Node`
+
+this  node
+
+#### Inherited from
+
+TransformNode.markAsDirty
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:340
+
+___
+
+### normalizeToUnitCube
+
+▸ **normalizeToUnitCube**(`includeDescendants?`, `ignoreRotation?`, `predicate?`): `TransformNode`
+
+Uniformly scales the mesh to fit inside of a unit cube (1 X 1 X 1 units)
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `includeDescendants?` | `boolean` | Use the hierarchy's bounding box instead of the mesh's bounding box. Default is false |
+| `ignoreRotation?` | `boolean` | ignore rotation when computing the scale (ie. object will be axis aligned). Default is false |
+| `predicate?` | (`node`: `AbstractMesh`) => `boolean` | predicate that is passed in to getHierarchyBoundingVectors when selecting which object should be included when scaling |
+
+#### Returns
+
+`TransformNode`
+
+the current mesh
+
+#### Inherited from
+
+TransformNode.normalizeToUnitCube
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:530
+
+___
+
+### registerAfterWorldMatrixUpdate
+
+▸ **registerAfterWorldMatrixUpdate**(`func`): `TransformNode`
+
+If you'd like to be called back after the mesh position, rotation or scaling has been updated.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `func` | (`mesh`: `TransformNode`) => `void` | callback function to add |
+
+#### Returns
+
+`TransformNode`
+
+the TransformNode.
+
+#### Inherited from
+
+TransformNode.registerAfterWorldMatrixUpdate
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:469
+
+___
+
+### removeBehavior
+
+▸ **removeBehavior**(`behavior`): `Node`
+
+Remove an attached behavior
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `behavior` | `Behavior`\<`Node`\> | defines the behavior to attach |
+
+#### Returns
+
+`Node`
+
+the current Node
+
+**`See`**
+
+https://doc.babylonjs.com/features/featuresDeepDive/behaviors
+
+#### Inherited from
+
+TransformNode.removeBehavior
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:210
+
+___
+
+### removeChild
+
+▸ **removeChild**(`mesh`, `preserveScalingSign?`): `this`
+
+Removes the passed mesh from the current mesh children list
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `mesh` | `TransformNode` | defines the child mesh |
+| `preserveScalingSign?` | `boolean` | if true, keep scaling sign of child. Otherwise, scaling sign might change. |
+
+#### Returns
+
+`this`
+
+the current mesh
+
+#### Inherited from
+
+TransformNode.removeChild
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:367
+
+___
+
+### resetLocalMatrix
+
+▸ **resetLocalMatrix**(`independentOfChildren?`): `void`
+
+Resets this nodeTransform's local matrix to Matrix.Identity().
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `independentOfChildren?` | `boolean` | indicates if all child nodeTransform's world-space transform should be preserved. |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.resetLocalMatrix
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:461
+
+___
+
+### rotate
+
+▸ **rotate**(`axis`, `amount`, `space?`): `TransformNode`
+
+Rotates the mesh around the axis vector for the passed angle (amount) expressed in radians, in the given space.
+space (default LOCAL) can be either Space.LOCAL, either Space.WORLD.
+Note that the property `rotationQuaternion` is then automatically updated and the property `rotation` is set to (0,0,0) and no longer used.
+The passed axis is also normalized.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `axis` | `Vector3` | the axis to rotate around |
+| `amount` | `number` | the amount to rotate in radians |
+| `space?` | `Space` | Space to rotate in (Default: local) |
+
+#### Returns
+
+`TransformNode`
+
+the TransformNode.
+
+#### Inherited from
+
+TransformNode.rotate
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:401
+
+___
+
+### rotateAround
+
+▸ **rotateAround**(`point`, `axis`, `amount`): `TransformNode`
+
+Rotates the mesh around the axis vector for the passed angle (amount) expressed in radians, in world space.
+Note that the property `rotationQuaternion` is then automatically updated and the property `rotation` is set to (0,0,0) and no longer used.
+The passed axis is also normalized. .
+Method is based on http://www.euclideanspace.com/maths/geometry/affine/aroundPoint/index.htm
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `point` | `Vector3` | the point to rotate around |
+| `axis` | `Vector3` | the axis to rotate around |
+| `amount` | `number` | the amount to rotate in radians |
+
+#### Returns
+
+`TransformNode`
+
+the TransformNode
+
+#### Inherited from
+
+TransformNode.rotateAround
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:412
+
+___
+
+### serialize
+
+▸ **serialize**(`currentSerializationObject?`): `any`
+
+Serializes the objects information.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `currentSerializationObject?` | `any` | defines the object to serialize in |
+
+#### Returns
+
+`any`
+
+the serialized object
+
+#### Inherited from
+
+TransformNode.serialize
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:501
+
+___
+
+### serializeAnimationRanges
+
+▸ **serializeAnimationRanges**(): `any`
+
+Serialize animation ranges into a JSON compatible object
+
+#### Returns
+
+`any`
+
+serialization object
+
+#### Inherited from
+
+TransformNode.serializeAnimationRanges
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:391
+
+___
+
+### setAbsolutePosition
+
+▸ **setAbsolutePosition**(`absolutePosition`): `TransformNode`
+
+Sets the mesh absolute position in the World from a Vector3 or an Array(3).
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `absolutePosition` | `Vector3` | the absolute position to set |
+
+#### Returns
+
+`TransformNode`
+
+the TransformNode.
+
+#### Inherited from
+
+TransformNode.setAbsolutePosition
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:252
+
+___
+
+### setDirection
+
+▸ **setDirection**(`localAxis`, `yawCor?`, `pitchCor?`, `rollCor?`): `TransformNode`
+
+Sets this transform node rotation to the given local axis.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `localAxis` | `Vector3` | the axis in local space |
+| `yawCor?` | `number` | optional yaw (y-axis) correction in radians |
+| `pitchCor?` | `number` | optional pitch (x-axis) correction in radians |
+| `rollCor?` | `number` | optional roll (z-axis) correction in radians |
+
+#### Returns
+
+`TransformNode`
+
+this TransformNode
+
+#### Inherited from
+
+TransformNode.setDirection
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:305
+
+___
+
+### setEnabled
+
+▸ **setEnabled**(`value`): `void`
+
+Set the enabled state of this node
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `value` | `boolean` | defines the new enabled state |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.setEnabled
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:282
+
+___
+
+### setParent
+
+▸ **setParent**(`node`, `preserveScalingSign?`, `updatePivot?`): `TransformNode`
+
+Defines the passed node as the parent of the current node.
+The node will remain exactly where it is and its position / rotation will be updated accordingly.
+Note that if the mesh has a pivot matrix / point defined it will be applied after the parent was updated.
+In that case the node will not remain in the same space as it is, as the pivot will be applied.
+To avoid this, you can set updatePivot to true and the pivot will be updated to identity
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `node` | `Node` | the node ot set as the parent |
+| `preserveScalingSign?` | `boolean` | if true, keep scaling sign of child. Otherwise, scaling sign might change. |
+| `updatePivot?` | `boolean` | if true, update the pivot matrix to keep the node in the same space as before |
+
+#### Returns
+
+`TransformNode`
+
+this TransformNode.
+
+**`See`**
+
+https://doc.babylonjs.com/features/featuresDeepDive/mesh/transforms/parent_pivot/parent
+
+#### Inherited from
+
+TransformNode.setParent
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:353
+
+___
+
+### setPivotMatrix
+
+▸ **setPivotMatrix**(`matrix`, `postMultiplyPivotMatrix?`): `TransformNode`
+
+Sets a new pivot matrix to the current node
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `matrix` | `DeepImmutableObject`\<`Matrix`\> | defines the new pivot matrix to use |
+| `postMultiplyPivotMatrix?` | `boolean` | defines if the pivot matrix must be cancelled in the world matrix. When this parameter is set to true (default), the inverse of the pivot matrix is also applied at the end to cancel the transformation effect |
+
+#### Returns
+
+`TransformNode`
+
+the current TransformNode
+
+#### Inherited from
+
+TransformNode.setPivotMatrix
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:208
+
+___
+
+### setPivotPoint
+
+▸ **setPivotPoint**(`point`, `space?`): `TransformNode`
+
+Sets a new pivot point to the current node
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `point` | `Vector3` | defines the new pivot point to use |
+| `space?` | `Space` | defines if the point is in world or local space (local by default) |
+
+#### Returns
+
+`TransformNode`
+
+the current TransformNode
+
+#### Inherited from
+
+TransformNode.setPivotPoint
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:312
+
+___
+
+### setPositionWithLocalVector
+
+▸ **setPositionWithLocalVector**(`vector3`): `TransformNode`
+
+Sets the mesh position in its local space.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `vector3` | `Vector3` | the position to set in localspace |
+
+#### Returns
+
+`TransformNode`
+
+the TransformNode.
+
+#### Inherited from
+
+TransformNode.setPositionWithLocalVector
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:258
+
+___
+
+### setPreTransformMatrix
+
+▸ **setPreTransformMatrix**(`matrix`): `TransformNode`
+
+Sets a new matrix to apply before all other transformation
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `matrix` | `Matrix` | defines the transform matrix |
+
+#### Returns
+
+`TransformNode`
+
+the current TransformNode
+
+#### Inherited from
+
+TransformNode.setPreTransformMatrix
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:201
+
+___
+
+### translate
+
+▸ **translate**(`axis`, `distance`, `space?`): `TransformNode`
+
+Translates the mesh along the axis vector for the passed distance in the given space.
+space (default LOCAL) can be either Space.LOCAL, either Space.WORLD.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `axis` | `Vector3` | the axis to translate in |
+| `distance` | `number` | the distance to translate |
+| `space?` | `Space` | Space to rotate in (Default: local) |
+
+#### Returns
+
+`TransformNode`
+
+the TransformNode.
+
+#### Inherited from
+
+TransformNode.translate
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:421
+
+___
+
+### unfreezeWorldMatrix
+
+▸ **unfreezeWorldMatrix**(): `this`
+
+Allows back the World matrix computation.
+
+#### Returns
+
+`this`
+
+the TransformNode.
+
+#### Inherited from
+
+TransformNode.unfreezeWorldMatrix
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:237
+
+___
+
+### unregisterAfterWorldMatrixUpdate
+
+▸ **unregisterAfterWorldMatrixUpdate**(`func`): `TransformNode`
+
+Removes a registered callback function.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `func` | (`mesh`: `TransformNode`) => `void` | callback function to remove |
+
+#### Returns
+
+`TransformNode`
+
+the TransformNode.
+
+#### Inherited from
+
+TransformNode.unregisterAfterWorldMatrixUpdate
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:475
+
+___
+
+### updateCache
+
+▸ **updateCache**(`force?`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `force?` | `boolean` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.updateCache
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:240
+
+___
+
+### updatePoseMatrix
+
+▸ **updatePoseMatrix**(`matrix`): `TransformNode`
+
+Copies the parameter passed Matrix into the mesh Pose matrix.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `matrix` | `Matrix` | the matrix to copy the pose from |
+
+#### Returns
+
+`TransformNode`
+
+this TransformNode.
+
+#### Inherited from
+
+TransformNode.updatePoseMatrix
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:171
+
+___
+
+### AddNodeConstructor
+
+▸ **AddNodeConstructor**(`type`, `constructorFunc`): `void`
+
+Add a new node constructor
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `type` | `string` | defines the type name of the node to construct |
+| `constructorFunc` | `NodeConstructor` | defines the constructor function |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.AddNodeConstructor
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:35
+
+___
+
+### Construct
+
+▸ **Construct**(`type`, `name`, `scene`, `options?`): () => `Node`
+
+Returns a node constructor based on type name
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `type` | `string` | defines the type name |
+| `name` | `string` | defines the new node name |
+| `scene` | `Scene` | defines the hosting scene |
+| `options?` | `any` | defines optional options to transmit to constructors |
+
+#### Returns
+
+`fn`
+
+the new constructor or null
+
+▸ (): `Node`
+
+##### Returns
+
+`Node`
+
+#### Inherited from
+
+TransformNode.Construct
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:44
+
+___
+
+### Parse
+
+▸ **Parse**(`parsedTransformNode`, `scene`, `rootUrl`): `TransformNode`
+
+Returns a new TransformNode object parsed from the source provided.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `parsedTransformNode` | `any` | is the source. |
+| `scene` | `Scene` | the scene the object belongs to |
+| `rootUrl` | `string` | is a string, it's the root URL to prefix the `delayLoadingFile` property with |
+
+#### Returns
+
+`TransformNode`
+
+a new TransformNode object parsed from the source provided.
+
+#### Inherited from
+
+TransformNode.Parse
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:509
+
+___
+
+### ParseAnimationRanges
+
+▸ **ParseAnimationRanges**(`node`, `parsedNode`, `_scene`): `void`
+
+Parse animation range data from a serialization object and store them into a given node
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `node` | `Node` | defines where to store the animation ranges |
+| `parsedNode` | `any` | defines the serialization object to read data from |
+| `_scene` | `Scene` | defines the hosting scene |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.ParseAnimationRanges
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:410

--- a/docs/api/classes/OrdinalChromatic.md
+++ b/docs/api/classes/OrdinalChromatic.md
@@ -38,7 +38,7 @@
 
 #### Defined in
 
-[prefabs/Chromatic/Chromatic.ts:7](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Chromatic/Chromatic.ts#L7)
+[src/prefabs/Chromatic/Chromatic.ts:7](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Chromatic/Chromatic.ts#L7)
 
 ## Properties
 
@@ -48,7 +48,7 @@
 
 #### Defined in
 
-[prefabs/Chromatic/Chromatic.ts:5](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Chromatic/Chromatic.ts#L5)
+[src/prefabs/Chromatic/Chromatic.ts:5](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Chromatic/Chromatic.ts#L5)
 
 ## Methods
 
@@ -68,7 +68,7 @@
 
 #### Defined in
 
-[prefabs/Chromatic/Chromatic.ts:11](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Chromatic/Chromatic.ts#L11)
+[src/prefabs/Chromatic/Chromatic.ts:11](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Chromatic/Chromatic.ts#L11)
 
 ___
 
@@ -88,7 +88,7 @@ ___
 
 #### Defined in
 
-[prefabs/Chromatic/Chromatic.ts:15](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Chromatic/Chromatic.ts#L15)
+[src/prefabs/Chromatic/Chromatic.ts:15](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Chromatic/Chromatic.ts#L15)
 
 ___
 
@@ -108,7 +108,7 @@ ___
 
 #### Defined in
 
-[prefabs/Chromatic/Chromatic.ts:27](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Chromatic/Chromatic.ts#L27)
+[src/prefabs/Chromatic/Chromatic.ts:27](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Chromatic/Chromatic.ts#L27)
 
 ___
 
@@ -128,7 +128,7 @@ ___
 
 #### Defined in
 
-[prefabs/Chromatic/Chromatic.ts:23](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Chromatic/Chromatic.ts#L23)
+[src/prefabs/Chromatic/Chromatic.ts:23](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Chromatic/Chromatic.ts#L23)
 
 ___
 
@@ -148,4 +148,4 @@ ___
 
 #### Defined in
 
-[prefabs/Chromatic/Chromatic.ts:19](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Chromatic/Chromatic.ts#L19)
+[src/prefabs/Chromatic/Chromatic.ts:19](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Chromatic/Chromatic.ts#L19)

--- a/docs/api/classes/PlaneText.md
+++ b/docs/api/classes/PlaneText.md
@@ -39,7 +39,7 @@
 
 #### Defined in
 
-[prefabs/Text/planeText.ts:25](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Text/planeText.ts#L25)
+[src/prefabs/Text/planeText.ts:25](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Text/planeText.ts#L25)
 
 ## Properties
 
@@ -49,7 +49,7 @@
 
 #### Defined in
 
-[prefabs/Text/planeText.ts:23](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Text/planeText.ts#L23)
+[src/prefabs/Text/planeText.ts:23](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Text/planeText.ts#L23)
 
 ___
 
@@ -59,7 +59,7 @@ ___
 
 #### Defined in
 
-[prefabs/Text/planeText.ts:20](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Text/planeText.ts#L20)
+[src/prefabs/Text/planeText.ts:20](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Text/planeText.ts#L20)
 
 ___
 
@@ -69,7 +69,7 @@ ___
 
 #### Defined in
 
-[prefabs/Text/planeText.ts:21](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Text/planeText.ts#L21)
+[src/prefabs/Text/planeText.ts:21](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Text/planeText.ts#L21)
 
 ___
 
@@ -79,7 +79,7 @@ ___
 
 #### Defined in
 
-[prefabs/Text/planeText.ts:22](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Text/planeText.ts#L22)
+[src/prefabs/Text/planeText.ts:22](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Text/planeText.ts#L22)
 
 ## Methods
 
@@ -93,4 +93,4 @@ ___
 
 #### Defined in
 
-[prefabs/Text/planeText.ts:32](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Text/planeText.ts#L32)
+[src/prefabs/Text/planeText.ts:32](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Text/planeText.ts#L32)

--- a/docs/api/classes/Selection.md
+++ b/docs/api/classes/Selection.md
@@ -17,6 +17,7 @@
 - [attr](Selection.md#attr)
 - [bind](Selection.md#bind)
 - [bindInstance](Selection.md#bindinstance)
+- [bindThinInstance](Selection.md#bindthininstance)
 - [boundingBox](Selection.md#boundingbox)
 - [diffuseColor](Selection.md#diffusecolor)
 - [diffuseTexture](Selection.md#diffusetexture)
@@ -55,6 +56,7 @@
 - [scalingZ](Selection.md#scalingz)
 - [scene](Selection.md#scene)
 - [select](Selection.md#select)
+- [selectData](Selection.md#selectdata)
 - [selectId](Selection.md#selectid)
 - [selectName](Selection.md#selectname)
 - [selectTag](Selection.md#selecttag)
@@ -62,7 +64,32 @@
 - [setInstancedBuffer](Selection.md#setinstancedbuffer)
 - [specularColor](Selection.md#specularcolor)
 - [specularTexture](Selection.md#speculartexture)
+- [thinInstanceAttributeAt](Selection.md#thininstanceattributeat)
+- [thinInstanceColor](Selection.md#thininstancecolor)
+- [thinInstanceColorAt](Selection.md#thininstancecolorat)
+- [thinInstanceColorFor](Selection.md#thininstancecolorfor)
+- [thinInstanceMatrixAt](Selection.md#thininstancematrixat)
+- [thinInstanceMatrixFor](Selection.md#thininstancematrixfor)
+- [thinInstancePosition](Selection.md#thininstanceposition)
+- [thinInstancePositionAt](Selection.md#thininstancepositionat)
+- [thinInstancePositionFor](Selection.md#thininstancepositionfor)
+- [thinInstanceRegisterAttribute](Selection.md#thininstanceregisterattribute)
+- [thinInstanceRotation](Selection.md#thininstancerotation)
+- [thinInstanceRotationAt](Selection.md#thininstancerotationat)
+- [thinInstanceRotationFor](Selection.md#thininstancerotationfor)
+- [thinInstanceScaling](Selection.md#thininstancescaling)
+- [thinInstanceScalingAt](Selection.md#thininstancescalingat)
+- [thinInstanceScalingFor](Selection.md#thininstancescalingfor)
+- [thinInstanceSetAttribute](Selection.md#thininstancesetattribute)
+- [thinInstanceSetBuffer](Selection.md#thininstancesetbuffer)
+- [transition](Selection.md#transition)
+- [transitions](Selection.md#transitions)
 - [translate](Selection.md#translate)
+- [tween](Selection.md#tween)
+
+### Methods
+
+- [updateTransitions](Selection.md#updatetransitions)
 
 ## Constructors
 
@@ -74,7 +101,7 @@
 
 | Name | Type |
 | :------ | :------ |
-| `nodes` | `Mesh`[] \| `Node`[] \| `TransformNode`[] |
+| `nodes` | `Mesh`[] \| `AbstractMesh`[] \| `TransformNode`[] \| `Node`[] |
 | `scene?` | `Scene` |
 
 #### Returns
@@ -83,7 +110,7 @@
 
 #### Defined in
 
-[selection/index.ts:46](https://github.com/jpmorganchase/anu/blob/4a68614/src/selection/index.ts#L46)
+[src/selection/index.ts:54](https://github.com/jpmorganchase/anu/blob/9b6add0/src/selection/index.ts#L54)
 
 ## Properties
 
@@ -108,7 +135,7 @@
 
 #### Defined in
 
-[selection/index.ts:76](https://github.com/jpmorganchase/anu/blob/4a68614/src/selection/index.ts#L76)
+[src/selection/index.ts:90](https://github.com/jpmorganchase/anu/blob/9b6add0/src/selection/index.ts#L90)
 
 ___
 
@@ -133,7 +160,7 @@ ___
 
 #### Defined in
 
-[selection/index.ts:73](https://github.com/jpmorganchase/anu/blob/4a68614/src/selection/index.ts#L73)
+[src/selection/index.ts:87](https://github.com/jpmorganchase/anu/blob/9b6add0/src/selection/index.ts#L87)
 
 ___
 
@@ -162,7 +189,7 @@ The modified selection
 
 #### Defined in
 
-[selection/index.ts:81](https://github.com/jpmorganchase/anu/blob/4a68614/src/selection/index.ts#L81)
+[src/selection/index.ts:95](https://github.com/jpmorganchase/anu/blob/9b6add0/src/selection/index.ts#L95)
 
 ___
 
@@ -191,7 +218,7 @@ The modified selection
 
 #### Defined in
 
-[selection/index.ts:88](https://github.com/jpmorganchase/anu/blob/4a68614/src/selection/index.ts#L88)
+[src/selection/index.ts:102](https://github.com/jpmorganchase/anu/blob/9b6add0/src/selection/index.ts#L102)
 
 ___
 
@@ -221,7 +248,7 @@ The modified selection
 
 #### Defined in
 
-[selection/index.ts:72](https://github.com/jpmorganchase/anu/blob/4a68614/src/selection/index.ts#L72)
+[src/selection/index.ts:86](https://github.com/jpmorganchase/anu/blob/9b6add0/src/selection/index.ts#L86)
 
 ___
 
@@ -260,7 +287,7 @@ or undefined if a selection could not be made.
 
 #### Defined in
 
-[selection/index.ts:55](https://github.com/jpmorganchase/anu/blob/4a68614/src/selection/index.ts#L55)
+[src/selection/index.ts:69](https://github.com/jpmorganchase/anu/blob/9b6add0/src/selection/index.ts#L69)
 
 ___
 
@@ -272,8 +299,8 @@ ___
 
 ▸ (`this`, `mesh`, `data?`): [`Selection`](Selection.md)
 
-Take a selection, a shape type, and data. For each index in the data create a new mesh for each node in the selection as the parrent.
-The data index of the mesh is also attached to the mesh node object under the metadate property.
+Take a selection, a shape type, and data. For each index in the data create a new mesh for each node in the selection as the parent.
+The data index of the mesh is also attached to the mesh node object under the metadata property.
 
 ##### Parameters
 
@@ -287,12 +314,44 @@ The data index of the mesh is also attached to the mesh node object under the me
 
 [`Selection`](Selection.md)
 
-An instance of Selection, a class contating a array of selected nodes, the scene, and the functions of the class Selection,
+An instance of Selection, a class containing a array of selected nodes, the scene, and the functions of the class Selection,
 or undefined if a selection could not be made.
 
 #### Defined in
 
-[selection/index.ts:57](https://github.com/jpmorganchase/anu/blob/4a68614/src/selection/index.ts#L57)
+[src/selection/index.ts:71](https://github.com/jpmorganchase/anu/blob/9b6add0/src/selection/index.ts#L71)
+
+___
+
+### bindThinInstance
+
+• **bindThinInstance**: (`this`: [`Selection`](Selection.md), `mesh`: `Mesh`, `data`: `object`[]) => [`Selection`](Selection.md) = `bindThinInstance`
+
+#### Type declaration
+
+▸ (`this`, `mesh`, `data?`): [`Selection`](Selection.md)
+
+Take a selection, a mesh, and data. For each index in the data create a new mesh for each node in the selection as the parent.
+The data index of the mesh is also attached to the mesh node object under the metadata property.
+
+##### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `this` | [`Selection`](Selection.md) | - |
+| `mesh` | `Mesh` | The mesh to create instances from. |
+| `data` | `object`[] | The data to bind elements too, must be passed as a list of objects where each object represents a row of tabular data. |
+
+##### Returns
+
+[`Selection`](Selection.md)
+
+An instance of Selection, a class containing a array of selected nodes, the scene, and the functions of the class Selection,
+or undefined if a selection could not be made.
+
+#### Defined in
+
+[src/selection/index.ts:134](https://github.com/jpmorganchase/anu/blob/9b6add0/src/selection/index.ts#L134)
 
 ___
 
@@ -321,7 +380,7 @@ instance of BoundingInfo class, an object containing all bounding box values.
 
 #### Defined in
 
-[selection/index.ts:92](https://github.com/jpmorganchase/anu/blob/4a68614/src/selection/index.ts#L92)
+[src/selection/index.ts:106](https://github.com/jpmorganchase/anu/blob/9b6add0/src/selection/index.ts#L106)
 
 ___
 
@@ -350,7 +409,7 @@ The modified selection
 
 #### Defined in
 
-[selection/index.ts:78](https://github.com/jpmorganchase/anu/blob/4a68614/src/selection/index.ts#L78)
+[src/selection/index.ts:92](https://github.com/jpmorganchase/anu/blob/9b6add0/src/selection/index.ts#L92)
 
 ___
 
@@ -379,7 +438,7 @@ The modified selection
 
 #### Defined in
 
-[selection/index.ts:85](https://github.com/jpmorganchase/anu/blob/4a68614/src/selection/index.ts#L85)
+[src/selection/index.ts:99](https://github.com/jpmorganchase/anu/blob/9b6add0/src/selection/index.ts#L99)
 
 ___
 
@@ -404,13 +463,13 @@ ___
 
 #### Defined in
 
-[selection/index.ts:84](https://github.com/jpmorganchase/anu/blob/4a68614/src/selection/index.ts#L84)
+[src/selection/index.ts:98](https://github.com/jpmorganchase/anu/blob/9b6add0/src/selection/index.ts#L98)
 
 ___
 
 ### drawTextDT
 
-• **drawTextDT**: (`this`: [`Selection`](Selection.md), `text`: `string` \| (`d`: `any`, `i`: `number`) => `string`, `font`: `string` \| (`d`: `any`, `i`: `number`) => `string`, `x`: ``null`` \| `number` \| (`d`: `any`, `i`: `number`) => `number`, `y`: ``null`` \| `number` \| (`d`: `any`, `i`: `number`) => `number`, `color`: ``null`` \| `string` \| (`d`: `any`, `i`: `number`) => `string`, `clearColor`: ``null`` \| `string` \| (`d`: `any`, `i`: `number`) => `string`) => [`Selection`](Selection.md) = `drawTextDT`
+• **drawTextDT**: (`this`: [`Selection`](Selection.md), `text`: `string` \| (`d`: `any`, `i`: `number`) => `string`, `font`: `string` \| (`d`: `any`, `i`: `number`) => `string`, `x`: `number` \| (`d`: `any`, `i`: `number`) => `number`, `y`: `number` \| (`d`: `any`, `i`: `number`) => `number`, `color`: `string` \| (`d`: `any`, `i`: `number`) => `string`, `clearColor`: `string` \| (`d`: `any`, `i`: `number`) => `string`) => [`Selection`](Selection.md) = `drawTextDT`
 
 #### Type declaration
 
@@ -423,10 +482,10 @@ ___
 | `this` | [`Selection`](Selection.md) | `undefined` |
 | `text` | `string` \| (`d`: `any`, `i`: `number`) => `string` | `undefined` |
 | `font` | `string` \| (`d`: `any`, `i`: `number`) => `string` | `undefined` |
-| `x` | ``null`` \| `number` \| (`d`: `any`, `i`: `number`) => `number` | `null` |
-| `y` | ``null`` \| `number` \| (`d`: `any`, `i`: `number`) => `number` | `null` |
-| `color` | ``null`` \| `string` \| (`d`: `any`, `i`: `number`) => `string` | `null` |
-| `clearColor` | ``null`` \| `string` \| (`d`: `any`, `i`: `number`) => `string` | `null` |
+| `x` | `number` \| (`d`: `any`, `i`: `number`) => `number` | `null` |
+| `y` | `number` \| (`d`: `any`, `i`: `number`) => `number` | `null` |
+| `color` | `string` \| (`d`: `any`, `i`: `number`) => `string` | `null` |
+| `clearColor` | `string` \| (`d`: `any`, `i`: `number`) => `string` | `null` |
 
 ##### Returns
 
@@ -434,7 +493,7 @@ ___
 
 #### Defined in
 
-[selection/index.ts:91](https://github.com/jpmorganchase/anu/blob/4a68614/src/selection/index.ts#L91)
+[src/selection/index.ts:105](https://github.com/jpmorganchase/anu/blob/9b6add0/src/selection/index.ts#L105)
 
 ___
 
@@ -463,7 +522,7 @@ The modified selection
 
 #### Defined in
 
-[selection/index.ts:80](https://github.com/jpmorganchase/anu/blob/4a68614/src/selection/index.ts#L80)
+[src/selection/index.ts:94](https://github.com/jpmorganchase/anu/blob/9b6add0/src/selection/index.ts#L94)
 
 ___
 
@@ -492,7 +551,7 @@ The modified selection
 
 #### Defined in
 
-[selection/index.ts:87](https://github.com/jpmorganchase/anu/blob/4a68614/src/selection/index.ts#L87)
+[src/selection/index.ts:101](https://github.com/jpmorganchase/anu/blob/9b6add0/src/selection/index.ts#L101)
 
 ___
 
@@ -521,7 +580,7 @@ The modified selection
 
 #### Defined in
 
-[selection/index.ts:93](https://github.com/jpmorganchase/anu/blob/4a68614/src/selection/index.ts#L93)
+[src/selection/index.ts:107](https://github.com/jpmorganchase/anu/blob/9b6add0/src/selection/index.ts#L107)
 
 ___
 
@@ -546,7 +605,7 @@ ___
 
 #### Defined in
 
-[selection/index.ts:71](https://github.com/jpmorganchase/anu/blob/4a68614/src/selection/index.ts#L71)
+[src/selection/index.ts:85](https://github.com/jpmorganchase/anu/blob/9b6add0/src/selection/index.ts#L85)
 
 ___
 
@@ -571,7 +630,7 @@ ___
 
 #### Defined in
 
-[selection/index.ts:75](https://github.com/jpmorganchase/anu/blob/4a68614/src/selection/index.ts#L75)
+[src/selection/index.ts:89](https://github.com/jpmorganchase/anu/blob/9b6add0/src/selection/index.ts#L89)
 
 ___
 
@@ -600,7 +659,7 @@ The modified selection
 
 #### Defined in
 
-[selection/index.ts:97](https://github.com/jpmorganchase/anu/blob/4a68614/src/selection/index.ts#L97)
+[src/selection/index.ts:111](https://github.com/jpmorganchase/anu/blob/9b6add0/src/selection/index.ts#L111)
 
 ___
 
@@ -629,7 +688,7 @@ The modified selection
 
 #### Defined in
 
-[selection/index.ts:77](https://github.com/jpmorganchase/anu/blob/4a68614/src/selection/index.ts#L77)
+[src/selection/index.ts:91](https://github.com/jpmorganchase/anu/blob/9b6add0/src/selection/index.ts#L91)
 
 ___
 
@@ -659,7 +718,7 @@ The modified selection
 
 #### Defined in
 
-[selection/index.ts:98](https://github.com/jpmorganchase/anu/blob/4a68614/src/selection/index.ts#L98)
+[src/selection/index.ts:112](https://github.com/jpmorganchase/anu/blob/9b6add0/src/selection/index.ts#L112)
 
 ___
 
@@ -688,7 +747,7 @@ The modified selection
 
 #### Defined in
 
-[selection/index.ts:96](https://github.com/jpmorganchase/anu/blob/4a68614/src/selection/index.ts#L96)
+[src/selection/index.ts:110](https://github.com/jpmorganchase/anu/blob/9b6add0/src/selection/index.ts#L110)
 
 ___
 
@@ -717,7 +776,7 @@ The modified selection
 
 #### Defined in
 
-[selection/index.ts:58](https://github.com/jpmorganchase/anu/blob/4a68614/src/selection/index.ts#L58)
+[src/selection/index.ts:72](https://github.com/jpmorganchase/anu/blob/9b6add0/src/selection/index.ts#L72)
 
 ___
 
@@ -747,7 +806,7 @@ or undefined if a selection could not be made.
 
 #### Defined in
 
-[selection/index.ts:99](https://github.com/jpmorganchase/anu/blob/4a68614/src/selection/index.ts#L99)
+[src/selection/index.ts:113](https://github.com/jpmorganchase/anu/blob/9b6add0/src/selection/index.ts#L113)
 
 ___
 
@@ -776,7 +835,7 @@ The modified selection
 
 #### Defined in
 
-[selection/index.ts:59](https://github.com/jpmorganchase/anu/blob/4a68614/src/selection/index.ts#L59)
+[src/selection/index.ts:73](https://github.com/jpmorganchase/anu/blob/9b6add0/src/selection/index.ts#L73)
 
 ___
 
@@ -805,7 +864,7 @@ The modified selection
 
 #### Defined in
 
-[selection/index.ts:60](https://github.com/jpmorganchase/anu/blob/4a68614/src/selection/index.ts#L60)
+[src/selection/index.ts:74](https://github.com/jpmorganchase/anu/blob/9b6add0/src/selection/index.ts#L74)
 
 ___
 
@@ -834,7 +893,7 @@ The modified selection
 
 #### Defined in
 
-[selection/index.ts:61](https://github.com/jpmorganchase/anu/blob/4a68614/src/selection/index.ts#L61)
+[src/selection/index.ts:75](https://github.com/jpmorganchase/anu/blob/9b6add0/src/selection/index.ts#L75)
 
 ___
 
@@ -864,7 +923,7 @@ The modified selection
 
 #### Defined in
 
-[selection/index.ts:95](https://github.com/jpmorganchase/anu/blob/4a68614/src/selection/index.ts#L95)
+[src/selection/index.ts:109](https://github.com/jpmorganchase/anu/blob/9b6add0/src/selection/index.ts#L109)
 
 ___
 
@@ -877,7 +936,7 @@ ___
 ▸ (`this`, `properties`): [`Selection`](Selection.md)
 
 Called from a selection this method allows you to set multiple properties or subproperties of nodes in the selection given that property exists.
-Use this method to improve performace when setting or changing many properties.
+Use this method to improve performance when setting or changing many properties.
 
 ##### Parameters
 
@@ -894,7 +953,7 @@ The modified selection
 
 #### Defined in
 
-[selection/index.ts:94](https://github.com/jpmorganchase/anu/blob/4a68614/src/selection/index.ts#L94)
+[src/selection/index.ts:108](https://github.com/jpmorganchase/anu/blob/9b6add0/src/selection/index.ts#L108)
 
 ___
 
@@ -920,7 +979,7 @@ ___
 
 #### Defined in
 
-[selection/index.ts:82](https://github.com/jpmorganchase/anu/blob/4a68614/src/selection/index.ts#L82)
+[src/selection/index.ts:96](https://github.com/jpmorganchase/anu/blob/9b6add0/src/selection/index.ts#L96)
 
 ___
 
@@ -945,7 +1004,7 @@ ___
 
 #### Defined in
 
-[selection/index.ts:74](https://github.com/jpmorganchase/anu/blob/4a68614/src/selection/index.ts#L74)
+[src/selection/index.ts:88](https://github.com/jpmorganchase/anu/blob/9b6add0/src/selection/index.ts#L88)
 
 ___
 
@@ -970,7 +1029,7 @@ ___
 
 #### Defined in
 
-[selection/index.ts:101](https://github.com/jpmorganchase/anu/blob/4a68614/src/selection/index.ts#L101)
+[src/selection/index.ts:115](https://github.com/jpmorganchase/anu/blob/9b6add0/src/selection/index.ts#L115)
 
 ___
 
@@ -999,7 +1058,7 @@ The modified selection
 
 #### Defined in
 
-[selection/index.ts:63](https://github.com/jpmorganchase/anu/blob/4a68614/src/selection/index.ts#L63)
+[src/selection/index.ts:77](https://github.com/jpmorganchase/anu/blob/9b6add0/src/selection/index.ts#L77)
 
 ___
 
@@ -1028,7 +1087,7 @@ The modified selection
 
 #### Defined in
 
-[selection/index.ts:64](https://github.com/jpmorganchase/anu/blob/4a68614/src/selection/index.ts#L64)
+[src/selection/index.ts:78](https://github.com/jpmorganchase/anu/blob/9b6add0/src/selection/index.ts#L78)
 
 ___
 
@@ -1057,7 +1116,7 @@ The modified selection
 
 #### Defined in
 
-[selection/index.ts:65](https://github.com/jpmorganchase/anu/blob/4a68614/src/selection/index.ts#L65)
+[src/selection/index.ts:79](https://github.com/jpmorganchase/anu/blob/9b6add0/src/selection/index.ts#L79)
 
 ___
 
@@ -1086,7 +1145,7 @@ The modified selection
 
 #### Defined in
 
-[selection/index.ts:66](https://github.com/jpmorganchase/anu/blob/4a68614/src/selection/index.ts#L66)
+[src/selection/index.ts:80](https://github.com/jpmorganchase/anu/blob/9b6add0/src/selection/index.ts#L80)
 
 ___
 
@@ -1111,7 +1170,7 @@ ___
 
 #### Defined in
 
-[selection/index.ts:56](https://github.com/jpmorganchase/anu/blob/4a68614/src/selection/index.ts#L56)
+[src/selection/index.ts:70](https://github.com/jpmorganchase/anu/blob/9b6add0/src/selection/index.ts#L70)
 
 ___
 
@@ -1136,7 +1195,7 @@ ___
 
 #### Defined in
 
-[selection/index.ts:89](https://github.com/jpmorganchase/anu/blob/4a68614/src/selection/index.ts#L89)
+[src/selection/index.ts:103](https://github.com/jpmorganchase/anu/blob/9b6add0/src/selection/index.ts#L103)
 
 ___
 
@@ -1161,7 +1220,7 @@ ___
 
 #### Defined in
 
-[selection/index.ts:90](https://github.com/jpmorganchase/anu/blob/4a68614/src/selection/index.ts#L90)
+[src/selection/index.ts:104](https://github.com/jpmorganchase/anu/blob/9b6add0/src/selection/index.ts#L104)
 
 ___
 
@@ -1186,7 +1245,7 @@ ___
 
 #### Defined in
 
-[selection/index.ts:100](https://github.com/jpmorganchase/anu/blob/4a68614/src/selection/index.ts#L100)
+[src/selection/index.ts:114](https://github.com/jpmorganchase/anu/blob/9b6add0/src/selection/index.ts#L114)
 
 ___
 
@@ -1215,7 +1274,7 @@ The modified selection
 
 #### Defined in
 
-[selection/index.ts:67](https://github.com/jpmorganchase/anu/blob/4a68614/src/selection/index.ts#L67)
+[src/selection/index.ts:81](https://github.com/jpmorganchase/anu/blob/9b6add0/src/selection/index.ts#L81)
 
 ___
 
@@ -1244,7 +1303,7 @@ The modified selection
 
 #### Defined in
 
-[selection/index.ts:68](https://github.com/jpmorganchase/anu/blob/4a68614/src/selection/index.ts#L68)
+[src/selection/index.ts:82](https://github.com/jpmorganchase/anu/blob/9b6add0/src/selection/index.ts#L82)
 
 ___
 
@@ -1273,7 +1332,7 @@ The modified selection
 
 #### Defined in
 
-[selection/index.ts:69](https://github.com/jpmorganchase/anu/blob/4a68614/src/selection/index.ts#L69)
+[src/selection/index.ts:83](https://github.com/jpmorganchase/anu/blob/9b6add0/src/selection/index.ts#L83)
 
 ___
 
@@ -1302,7 +1361,7 @@ The modified selection
 
 #### Defined in
 
-[selection/index.ts:70](https://github.com/jpmorganchase/anu/blob/4a68614/src/selection/index.ts#L70)
+[src/selection/index.ts:84](https://github.com/jpmorganchase/anu/blob/9b6add0/src/selection/index.ts#L84)
 
 ___
 
@@ -1312,7 +1371,7 @@ ___
 
 #### Defined in
 
-[selection/index.ts:44](https://github.com/jpmorganchase/anu/blob/4a68614/src/selection/index.ts#L44)
+[src/selection/index.ts:50](https://github.com/jpmorganchase/anu/blob/9b6add0/src/selection/index.ts#L50)
 
 ___
 
@@ -1345,7 +1404,37 @@ $\<Tags> : select by tags
 
 #### Defined in
 
-[selection/index.ts:51](https://github.com/jpmorganchase/anu/blob/4a68614/src/selection/index.ts#L51)
+[src/selection/index.ts:64](https://github.com/jpmorganchase/anu/blob/9b6add0/src/selection/index.ts#L64)
+
+___
+
+### selectData
+
+• **selectData**: (`this`: [`Selection`](Selection.md), `key`: `string` \| `string`[], `value`: `string` \| `number` \| `string`[] \| `number`[]) => [`Selection`](Selection.md) = `selectData`
+
+#### Type declaration
+
+▸ (`this`, `key`, `value`): [`Selection`](Selection.md)
+
+Select nodes from the childern graph(s) of a selection by key value pairs or list of key value pairs and return them as a instance of Selection.
+
+##### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `this` | [`Selection`](Selection.md) | - |
+| `key` | `string` \| `string`[] | A string or array of strings of the keys to be searched. |
+| `value` | `string` \| `number` \| `string`[] \| `number`[] | - |
+
+##### Returns
+
+[`Selection`](Selection.md)
+
+A new instance of Selection with the selected nodes.
+
+#### Defined in
+
+[src/selection/index.ts:68](https://github.com/jpmorganchase/anu/blob/9b6add0/src/selection/index.ts#L68)
 
 ___
 
@@ -1374,7 +1463,7 @@ A new instance of Selection with the selected nodes.
 
 #### Defined in
 
-[selection/index.ts:53](https://github.com/jpmorganchase/anu/blob/4a68614/src/selection/index.ts#L53)
+[src/selection/index.ts:66](https://github.com/jpmorganchase/anu/blob/9b6add0/src/selection/index.ts#L66)
 
 ___
 
@@ -1403,7 +1492,7 @@ A new instance of Selection with the selected nodes.
 
 #### Defined in
 
-[selection/index.ts:52](https://github.com/jpmorganchase/anu/blob/4a68614/src/selection/index.ts#L52)
+[src/selection/index.ts:65](https://github.com/jpmorganchase/anu/blob/9b6add0/src/selection/index.ts#L65)
 
 ___
 
@@ -1432,17 +1521,17 @@ A new instance of Selection with the selected nodes.
 
 #### Defined in
 
-[selection/index.ts:54](https://github.com/jpmorganchase/anu/blob/4a68614/src/selection/index.ts#L54)
+[src/selection/index.ts:67](https://github.com/jpmorganchase/anu/blob/9b6add0/src/selection/index.ts#L67)
 
 ___
 
 ### selected
 
-• **selected**: `Mesh`[] \| `Node`[] \| `TransformNode`[]
+• **selected**: `Mesh`[] \| `AbstractMesh`[] \| `TransformNode`[] \| `Node`[]
 
 #### Defined in
 
-[selection/index.ts:43](https://github.com/jpmorganchase/anu/blob/4a68614/src/selection/index.ts#L43)
+[src/selection/index.ts:49](https://github.com/jpmorganchase/anu/blob/9b6add0/src/selection/index.ts#L49)
 
 ___
 
@@ -1468,7 +1557,7 @@ ___
 
 #### Defined in
 
-[selection/index.ts:83](https://github.com/jpmorganchase/anu/blob/4a68614/src/selection/index.ts#L83)
+[src/selection/index.ts:97](https://github.com/jpmorganchase/anu/blob/9b6add0/src/selection/index.ts#L97)
 
 ___
 
@@ -1497,7 +1586,7 @@ The modified selection
 
 #### Defined in
 
-[selection/index.ts:79](https://github.com/jpmorganchase/anu/blob/4a68614/src/selection/index.ts#L79)
+[src/selection/index.ts:93](https://github.com/jpmorganchase/anu/blob/9b6add0/src/selection/index.ts#L93)
 
 ___
 
@@ -1526,7 +1615,517 @@ The modified selection
 
 #### Defined in
 
-[selection/index.ts:86](https://github.com/jpmorganchase/anu/blob/4a68614/src/selection/index.ts#L86)
+[src/selection/index.ts:100](https://github.com/jpmorganchase/anu/blob/9b6add0/src/selection/index.ts#L100)
+
+___
+
+### thinInstanceAttributeAt
+
+• **thinInstanceAttributeAt**: (`this`: [`Selection`](Selection.md), `attribute`: `string`, `index`: `number`, `value`: `any`) => [`Selection`](Selection.md) = `thinInstanceAttributeAt`
+
+#### Type declaration
+
+▸ (`this`, `attribute`, `index`, `value`): [`Selection`](Selection.md)
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `this` | [`Selection`](Selection.md) |
+| `attribute` | `string` |
+| `index` | `number` |
+| `value` | `any` |
+
+##### Returns
+
+[`Selection`](Selection.md)
+
+#### Defined in
+
+[src/selection/index.ts:122](https://github.com/jpmorganchase/anu/blob/9b6add0/src/selection/index.ts#L122)
+
+___
+
+### thinInstanceColor
+
+• **thinInstanceColor**: (`this`: [`Selection`](Selection.md), `value`: `Color4` \| (`d`: `any`, `n`: `Node`, `i`: `number`) => `Color4`, `staticBuffer`: `boolean`) => [`Selection`](Selection.md) = `thinInstanceColor`
+
+#### Type declaration
+
+▸ (`this`, `value`, `staticBuffer?`): [`Selection`](Selection.md)
+
+##### Parameters
+
+| Name | Type | Default value |
+| :------ | :------ | :------ |
+| `this` | [`Selection`](Selection.md) | `undefined` |
+| `value` | `Color4` \| (`d`: `any`, `n`: `Node`, `i`: `number`) => `Color4` | `undefined` |
+| `staticBuffer` | `boolean` | `false` |
+
+##### Returns
+
+[`Selection`](Selection.md)
+
+#### Defined in
+
+[src/selection/index.ts:120](https://github.com/jpmorganchase/anu/blob/9b6add0/src/selection/index.ts#L120)
+
+___
+
+### thinInstanceColorAt
+
+• **thinInstanceColorAt**: (`this`: [`Selection`](Selection.md), `index`: `number`, `value`: `Color4` \| (`d`: `any`, `n`: `Node`, `i`: `number`) => `Color4`) => [`Selection`](Selection.md) = `thinInstanceColorAt`
+
+#### Type declaration
+
+▸ (`this`, `index`, `value`): [`Selection`](Selection.md)
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `this` | [`Selection`](Selection.md) |
+| `index` | `number` |
+| `value` | `Color4` \| (`d`: `any`, `n`: `Node`, `i`: `number`) => `Color4` |
+
+##### Returns
+
+[`Selection`](Selection.md)
+
+#### Defined in
+
+[src/selection/index.ts:129](https://github.com/jpmorganchase/anu/blob/9b6add0/src/selection/index.ts#L129)
+
+___
+
+### thinInstanceColorFor
+
+• **thinInstanceColorFor**: (`this`: [`Selection`](Selection.md), `method`: (`d`: `any`, `n`: `Node`, `i`: `number`) => `boolean`, `value`: `Color4` \| (`d`: `any`, `n`: `Node`, `i`: `number`) => `Color4`) => [`Selection`](Selection.md) = `thinInstanceColorFor`
+
+#### Type declaration
+
+▸ (`this`, `method`, `value`): [`Selection`](Selection.md)
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `this` | [`Selection`](Selection.md) |
+| `method` | (`d`: `any`, `n`: `Node`, `i`: `number`) => `boolean` |
+| `value` | `Color4` \| (`d`: `any`, `n`: `Node`, `i`: `number`) => `Color4` |
+
+##### Returns
+
+[`Selection`](Selection.md)
+
+#### Defined in
+
+[src/selection/index.ts:133](https://github.com/jpmorganchase/anu/blob/9b6add0/src/selection/index.ts#L133)
+
+___
+
+### thinInstanceMatrixAt
+
+• **thinInstanceMatrixAt**: (`this`: [`Selection`](Selection.md), `index`: `number`, `value`: `Matrix` \| (`d`: `any`, `n`: `Node`, `i`: `number`) => `Matrix`) => [`Selection`](Selection.md) = `thinInstanceMatrixAt`
+
+#### Type declaration
+
+▸ (`this`, `index`, `value`): [`Selection`](Selection.md)
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `this` | [`Selection`](Selection.md) |
+| `index` | `number` |
+| `value` | `Matrix` \| (`d`: `any`, `n`: `Node`, `i`: `number`) => `Matrix` |
+
+##### Returns
+
+[`Selection`](Selection.md)
+
+#### Defined in
+
+[src/selection/index.ts:124](https://github.com/jpmorganchase/anu/blob/9b6add0/src/selection/index.ts#L124)
+
+___
+
+### thinInstanceMatrixFor
+
+• **thinInstanceMatrixFor**: (`this`: [`Selection`](Selection.md), `method`: (`d`: `any`, `n`: `Node`, `i`: `number`) => `boolean`, `value`: `Matrix` \| (`d`: `any`, `n`: `Node`, `i`: `number`) => `Matrix`) => [`Selection`](Selection.md) = `thinInstanceMatrixFor`
+
+#### Type declaration
+
+▸ (`this`, `method`, `value`): [`Selection`](Selection.md)
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `this` | [`Selection`](Selection.md) |
+| `method` | (`d`: `any`, `n`: `Node`, `i`: `number`) => `boolean` |
+| `value` | `Matrix` \| (`d`: `any`, `n`: `Node`, `i`: `number`) => `Matrix` |
+
+##### Returns
+
+[`Selection`](Selection.md)
+
+#### Defined in
+
+[src/selection/index.ts:125](https://github.com/jpmorganchase/anu/blob/9b6add0/src/selection/index.ts#L125)
+
+___
+
+### thinInstancePosition
+
+• **thinInstancePosition**: (`this`: [`Selection`](Selection.md), `value`: `Vector3` \| (`d`: `any`, `n`: `Node`, `i`: `number`) => `Vector3`, `staticBuffer`: `boolean`) => [`Selection`](Selection.md) = `thinInstancePosition`
+
+#### Type declaration
+
+▸ (`this`, `value`, `staticBuffer?`): [`Selection`](Selection.md)
+
+##### Parameters
+
+| Name | Type | Default value |
+| :------ | :------ | :------ |
+| `this` | [`Selection`](Selection.md) | `undefined` |
+| `value` | `Vector3` \| (`d`: `any`, `n`: `Node`, `i`: `number`) => `Vector3` | `undefined` |
+| `staticBuffer` | `boolean` | `false` |
+
+##### Returns
+
+[`Selection`](Selection.md)
+
+#### Defined in
+
+[src/selection/index.ts:117](https://github.com/jpmorganchase/anu/blob/9b6add0/src/selection/index.ts#L117)
+
+___
+
+### thinInstancePositionAt
+
+• **thinInstancePositionAt**: (`this`: [`Selection`](Selection.md), `index`: `number`, `value`: `Vector3` \| (`d`: `any`, `n`: `Node`, `i`: `number`) => `Vector3`) => [`Selection`](Selection.md) = `thinInstancePositionAt`
+
+#### Type declaration
+
+▸ (`this`, `index`, `value`): [`Selection`](Selection.md)
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `this` | [`Selection`](Selection.md) |
+| `index` | `number` |
+| `value` | `Vector3` \| (`d`: `any`, `n`: `Node`, `i`: `number`) => `Vector3` |
+
+##### Returns
+
+[`Selection`](Selection.md)
+
+#### Defined in
+
+[src/selection/index.ts:126](https://github.com/jpmorganchase/anu/blob/9b6add0/src/selection/index.ts#L126)
+
+___
+
+### thinInstancePositionFor
+
+• **thinInstancePositionFor**: (`this`: [`Selection`](Selection.md), `method`: (`d`: `any`, `n`: `Node`, `i`: `number`) => `boolean`, `value`: `Vector3` \| (`d`: `any`, `n`: `Node`, `i`: `number`) => `Vector3`) => [`Selection`](Selection.md) = `thinInstancePositionFor`
+
+#### Type declaration
+
+▸ (`this`, `method`, `value`): [`Selection`](Selection.md)
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `this` | [`Selection`](Selection.md) |
+| `method` | (`d`: `any`, `n`: `Node`, `i`: `number`) => `boolean` |
+| `value` | `Vector3` \| (`d`: `any`, `n`: `Node`, `i`: `number`) => `Vector3` |
+
+##### Returns
+
+[`Selection`](Selection.md)
+
+#### Defined in
+
+[src/selection/index.ts:130](https://github.com/jpmorganchase/anu/blob/9b6add0/src/selection/index.ts#L130)
+
+___
+
+### thinInstanceRegisterAttribute
+
+• **thinInstanceRegisterAttribute**: (`this`: [`Selection`](Selection.md), `attribute`: `string`, `stride`: `number`) => [`Selection`](Selection.md) = `thinInstanceRegisterAttribute`
+
+#### Type declaration
+
+▸ (`this`, `attribute`, `stride`): [`Selection`](Selection.md)
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `this` | [`Selection`](Selection.md) |
+| `attribute` | `string` |
+| `stride` | `number` |
+
+##### Returns
+
+[`Selection`](Selection.md)
+
+#### Defined in
+
+[src/selection/index.ts:123](https://github.com/jpmorganchase/anu/blob/9b6add0/src/selection/index.ts#L123)
+
+___
+
+### thinInstanceRotation
+
+• **thinInstanceRotation**: (`this`: [`Selection`](Selection.md), `value`: `Vector3` \| (`d`: `any`, `n`: `Node`, `i`: `number`) => `Vector3`, `staticBuffer`: `boolean`) => [`Selection`](Selection.md) = `thinInstanceRotation`
+
+#### Type declaration
+
+▸ (`this`, `value`, `staticBuffer?`): [`Selection`](Selection.md)
+
+##### Parameters
+
+| Name | Type | Default value |
+| :------ | :------ | :------ |
+| `this` | [`Selection`](Selection.md) | `undefined` |
+| `value` | `Vector3` \| (`d`: `any`, `n`: `Node`, `i`: `number`) => `Vector3` | `undefined` |
+| `staticBuffer` | `boolean` | `false` |
+
+##### Returns
+
+[`Selection`](Selection.md)
+
+#### Defined in
+
+[src/selection/index.ts:119](https://github.com/jpmorganchase/anu/blob/9b6add0/src/selection/index.ts#L119)
+
+___
+
+### thinInstanceRotationAt
+
+• **thinInstanceRotationAt**: (`this`: [`Selection`](Selection.md), `index`: `number`, `value`: `Vector3` \| (`d`: `any`, `n`: `Node`, `i`: `number`) => `Vector3`) => [`Selection`](Selection.md) = `thinInstanceRotationAt`
+
+#### Type declaration
+
+▸ (`this`, `index`, `value`): [`Selection`](Selection.md)
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `this` | [`Selection`](Selection.md) |
+| `index` | `number` |
+| `value` | `Vector3` \| (`d`: `any`, `n`: `Node`, `i`: `number`) => `Vector3` |
+
+##### Returns
+
+[`Selection`](Selection.md)
+
+#### Defined in
+
+[src/selection/index.ts:128](https://github.com/jpmorganchase/anu/blob/9b6add0/src/selection/index.ts#L128)
+
+___
+
+### thinInstanceRotationFor
+
+• **thinInstanceRotationFor**: (`this`: [`Selection`](Selection.md), `method`: (`d`: `any`, `n`: `Node`, `i`: `number`) => `boolean`, `value`: `Vector3` \| (`d`: `any`, `n`: `Node`, `i`: `number`) => `Vector3`) => [`Selection`](Selection.md) = `thinInstanceRotationFor`
+
+#### Type declaration
+
+▸ (`this`, `method`, `value`): [`Selection`](Selection.md)
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `this` | [`Selection`](Selection.md) |
+| `method` | (`d`: `any`, `n`: `Node`, `i`: `number`) => `boolean` |
+| `value` | `Vector3` \| (`d`: `any`, `n`: `Node`, `i`: `number`) => `Vector3` |
+
+##### Returns
+
+[`Selection`](Selection.md)
+
+#### Defined in
+
+[src/selection/index.ts:132](https://github.com/jpmorganchase/anu/blob/9b6add0/src/selection/index.ts#L132)
+
+___
+
+### thinInstanceScaling
+
+• **thinInstanceScaling**: (`this`: [`Selection`](Selection.md), `value`: `Vector3` \| (`d`: `any`, `n`: `Node`, `i`: `number`) => `Vector3`, `staticBuffer`: `boolean`) => [`Selection`](Selection.md) = `thinInstanceScaling`
+
+#### Type declaration
+
+▸ (`this`, `value`, `staticBuffer?`): [`Selection`](Selection.md)
+
+##### Parameters
+
+| Name | Type | Default value |
+| :------ | :------ | :------ |
+| `this` | [`Selection`](Selection.md) | `undefined` |
+| `value` | `Vector3` \| (`d`: `any`, `n`: `Node`, `i`: `number`) => `Vector3` | `undefined` |
+| `staticBuffer` | `boolean` | `false` |
+
+##### Returns
+
+[`Selection`](Selection.md)
+
+#### Defined in
+
+[src/selection/index.ts:118](https://github.com/jpmorganchase/anu/blob/9b6add0/src/selection/index.ts#L118)
+
+___
+
+### thinInstanceScalingAt
+
+• **thinInstanceScalingAt**: (`this`: [`Selection`](Selection.md), `index`: `number`, `value`: `Vector3` \| (`d`: `any`, `n`: `Node`, `i`: `number`) => `Vector3`) => [`Selection`](Selection.md) = `thinInstanceScalingAt`
+
+#### Type declaration
+
+▸ (`this`, `index`, `value`): [`Selection`](Selection.md)
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `this` | [`Selection`](Selection.md) |
+| `index` | `number` |
+| `value` | `Vector3` \| (`d`: `any`, `n`: `Node`, `i`: `number`) => `Vector3` |
+
+##### Returns
+
+[`Selection`](Selection.md)
+
+#### Defined in
+
+[src/selection/index.ts:127](https://github.com/jpmorganchase/anu/blob/9b6add0/src/selection/index.ts#L127)
+
+___
+
+### thinInstanceScalingFor
+
+• **thinInstanceScalingFor**: (`this`: [`Selection`](Selection.md), `method`: (`d`: `any`, `n`: `Node`, `i`: `number`) => `boolean`, `value`: `Vector3` \| (`d`: `any`, `n`: `Node`, `i`: `number`) => `Vector3`) => [`Selection`](Selection.md) = `thinInstanceScalingFor`
+
+#### Type declaration
+
+▸ (`this`, `method`, `value`): [`Selection`](Selection.md)
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `this` | [`Selection`](Selection.md) |
+| `method` | (`d`: `any`, `n`: `Node`, `i`: `number`) => `boolean` |
+| `value` | `Vector3` \| (`d`: `any`, `n`: `Node`, `i`: `number`) => `Vector3` |
+
+##### Returns
+
+[`Selection`](Selection.md)
+
+#### Defined in
+
+[src/selection/index.ts:131](https://github.com/jpmorganchase/anu/blob/9b6add0/src/selection/index.ts#L131)
+
+___
+
+### thinInstanceSetAttribute
+
+• **thinInstanceSetAttribute**: (`this`: [`Selection`](Selection.md), `attribute`: `string`, `value`: `any`) => [`Selection`](Selection.md) = `thinInstanceSetAttribute`
+
+#### Type declaration
+
+▸ (`this`, `attribute`, `value`): [`Selection`](Selection.md)
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `this` | [`Selection`](Selection.md) |
+| `attribute` | `string` |
+| `value` | `any` |
+
+##### Returns
+
+[`Selection`](Selection.md)
+
+#### Defined in
+
+[src/selection/index.ts:121](https://github.com/jpmorganchase/anu/blob/9b6add0/src/selection/index.ts#L121)
+
+___
+
+### thinInstanceSetBuffer
+
+• **thinInstanceSetBuffer**: (`this`: [`Selection`](Selection.md), `attribute`: `string`, `value`: `Float32Array` \| (`d`: `any`, `n`: `Node`, `i`: `number`) => `Float32Array`, `stride?`: `number`, `staticBuffer`: `boolean`) => [`Selection`](Selection.md) = `thinInstanceSetBuffer`
+
+#### Type declaration
+
+▸ (`this`, `attribute`, `value`, `stride?`, `staticBuffer?`): [`Selection`](Selection.md)
+
+##### Parameters
+
+| Name | Type | Default value |
+| :------ | :------ | :------ |
+| `this` | [`Selection`](Selection.md) | `undefined` |
+| `attribute` | `string` | `undefined` |
+| `value` | `Float32Array` \| (`d`: `any`, `n`: `Node`, `i`: `number`) => `Float32Array` | `undefined` |
+| `stride?` | `number` | `undefined` |
+| `staticBuffer` | `boolean` | `false` |
+
+##### Returns
+
+[`Selection`](Selection.md)
+
+#### Defined in
+
+[src/selection/index.ts:116](https://github.com/jpmorganchase/anu/blob/9b6add0/src/selection/index.ts#L116)
+
+___
+
+### transition
+
+• **transition**: (`this`: [`Selection`](Selection.md), `options`: `TransitionOptions` \| (`d`: `any`, `n`: `Node`, `i`: `number`) => `TransitionOptions`) => [`Selection`](Selection.md) = `transition`
+
+#### Type declaration
+
+▸ (`this`, `options`): [`Selection`](Selection.md)
+
+Initiates and returns a new transition selection object or adds a new transition sequence to an existing transition selection object. This method is called from a selection and is used to animate the change in transforms of each node in the selection. The transition can be customized using the provided options or a function that returns options for each node.
+
+##### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `this` | [`Selection`](Selection.md) | - |
+| `options` | `TransitionOptions` \| (`d`: `any`, `n`: `Node`, `i`: `number`) => `TransitionOptions` | The transition options to apply. This can be a `TransitionOptions` object or a function that returns a `TransitionOptions` object for each node. The function receives the data bound to the node, the node itself, and the index of the node as arguments. TransitionOptions: - `duration` (optional): The duration of the transition in milliseconds. - `delay` (optional): The delay before the transition starts, in milliseconds. - `framePerSecond` (optional): The number of frames per second for the transition. - `sequence` (optional): A boolean indicating whether the transition should be part of a sequence. - `easingFunction` (optional): An easing function to control the transition's rate of change. - `loopMode` (optional): A number (0 to 4) indicating the loop mode for the transition. - `onAnimationEnd` (optional): A callback function to be executed when the transition ends. |
+
+##### Returns
+
+[`Selection`](Selection.md)
+
+The modified transition selection.
+
+#### Defined in
+
+[src/selection/index.ts:135](https://github.com/jpmorganchase/anu/blob/9b6add0/src/selection/index.ts#L135)
+
+___
+
+### transitions
+
+• **transitions**: `Transition`[]
+
+#### Defined in
+
+[src/selection/index.ts:51](https://github.com/jpmorganchase/anu/blob/9b6add0/src/selection/index.ts#L51)
 
 ___
 
@@ -1553,4 +2152,53 @@ ___
 
 #### Defined in
 
-[selection/index.ts:62](https://github.com/jpmorganchase/anu/blob/4a68614/src/selection/index.ts#L62)
+[src/selection/index.ts:76](https://github.com/jpmorganchase/anu/blob/9b6add0/src/selection/index.ts#L76)
+
+___
+
+### tween
+
+• **tween**: (`this`: [`Selection`](Selection.md), `value`: (`d`: `any`, `n`: `any`, `i`: `any`) => (`t`: `any`) => `void`) => [`Selection`](Selection.md) = `tween`
+
+#### Type declaration
+
+▸ (`this`, `value`): [`Selection`](Selection.md)
+
+Applies a tweening function to each node in the selection, returning a eased time value between 0-1 to be used for animation control for the total duration of the transition. The tweening function is executed for each node, allowing for fine-grained control over the animation process.
+
+##### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `this` | [`Selection`](Selection.md) | - |
+| `value` | (`d`: `any`, `n`: `any`, `i`: `any`) => (`t`: `any`) => `void` | A function that returns a tweening function for each node. The outer function receives the data bound to the node, the node itself, and the index of the node as arguments. The returned tweening function is called with a parameter `t` that represents the normalized time (from 0 to 1) of the animation. |
+
+##### Returns
+
+[`Selection`](Selection.md)
+
+The modified selection with the applied tweening animations.
+
+#### Defined in
+
+[src/selection/index.ts:136](https://github.com/jpmorganchase/anu/blob/9b6add0/src/selection/index.ts#L136)
+
+## Methods
+
+### updateTransitions
+
+▸ **updateTransitions**(`transition`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `transition` | `Transition` |
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+[src/selection/index.ts:60](https://github.com/jpmorganchase/anu/blob/9b6add0/src/selection/index.ts#L60)

--- a/docs/api/classes/SequentialChromatic.md
+++ b/docs/api/classes/SequentialChromatic.md
@@ -38,7 +38,7 @@
 
 #### Defined in
 
-[prefabs/Chromatic/Chromatic.ts:36](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Chromatic/Chromatic.ts#L36)
+[src/prefabs/Chromatic/Chromatic.ts:36](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Chromatic/Chromatic.ts#L36)
 
 ## Properties
 
@@ -48,7 +48,7 @@
 
 #### Defined in
 
-[prefabs/Chromatic/Chromatic.ts:34](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Chromatic/Chromatic.ts#L34)
+[src/prefabs/Chromatic/Chromatic.ts:34](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Chromatic/Chromatic.ts#L34)
 
 ## Methods
 
@@ -60,7 +60,7 @@
 
 | Name | Type | Default value |
 | :------ | :------ | :------ |
-| `steps` | `undefined` \| `number` \| `number`[] | `undefined` |
+| `steps` | `number` \| `number`[] | `undefined` |
 
 #### Returns
 
@@ -80,7 +80,7 @@
 
 #### Defined in
 
-[prefabs/Chromatic/Chromatic.ts:40](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Chromatic/Chromatic.ts#L40)
+[src/prefabs/Chromatic/Chromatic.ts:40](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Chromatic/Chromatic.ts#L40)
 
 ___
 
@@ -92,7 +92,7 @@ ___
 
 | Name | Type | Default value |
 | :------ | :------ | :------ |
-| `steps` | `undefined` \| `number` \| `number`[] | `undefined` |
+| `steps` | `number` \| `number`[] | `undefined` |
 
 #### Returns
 
@@ -112,7 +112,7 @@ ___
 
 #### Defined in
 
-[prefabs/Chromatic/Chromatic.ts:47](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Chromatic/Chromatic.ts#L47)
+[src/prefabs/Chromatic/Chromatic.ts:47](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Chromatic/Chromatic.ts#L47)
 
 ___
 
@@ -124,7 +124,7 @@ ___
 
 | Name | Type | Default value |
 | :------ | :------ | :------ |
-| `steps` | `undefined` \| `number` \| `number`[] | `undefined` |
+| `steps` | `number` \| `number`[] | `undefined` |
 
 #### Returns
 
@@ -144,7 +144,7 @@ ___
 
 #### Defined in
 
-[prefabs/Chromatic/Chromatic.ts:62](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Chromatic/Chromatic.ts#L62)
+[src/prefabs/Chromatic/Chromatic.ts:62](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Chromatic/Chromatic.ts#L62)
 
 ___
 
@@ -156,7 +156,7 @@ ___
 
 | Name | Type | Default value |
 | :------ | :------ | :------ |
-| `steps` | `undefined` \| `number` \| `number`[] | `undefined` |
+| `steps` | `number` \| `number`[] | `undefined` |
 
 #### Returns
 
@@ -176,7 +176,7 @@ ___
 
 #### Defined in
 
-[prefabs/Chromatic/Chromatic.ts:57](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Chromatic/Chromatic.ts#L57)
+[src/prefabs/Chromatic/Chromatic.ts:57](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Chromatic/Chromatic.ts#L57)
 
 ___
 
@@ -188,7 +188,7 @@ ___
 
 | Name | Type | Default value |
 | :------ | :------ | :------ |
-| `steps` | `undefined` \| `number` \| `number`[] | `undefined` |
+| `steps` | `number` \| `number`[] | `undefined` |
 
 #### Returns
 
@@ -208,4 +208,4 @@ ___
 
 #### Defined in
 
-[prefabs/Chromatic/Chromatic.ts:52](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Chromatic/Chromatic.ts#L52)
+[src/prefabs/Chromatic/Chromatic.ts:52](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Chromatic/Chromatic.ts#L52)

--- a/docs/api/classes/TextureGlobe.md
+++ b/docs/api/classes/TextureGlobe.md
@@ -2,6 +2,12 @@
 
 # Class: TextureGlobe
 
+## Hierarchy
+
+- `TransformNode`
+
+  ↳ **`TextureGlobe`**
+
 ## Table of contents
 
 ### Constructors
@@ -10,27 +16,197 @@
 
 ### Properties
 
+- [\_accessibilityTag](TextureGlobe.md#_accessibilitytag)
+- [\_cache](TextureGlobe.md#_cache)
+- [\_childUpdateId](TextureGlobe.md#_childupdateid)
+- [\_children](TextureGlobe.md#_children)
+- [\_currentRenderId](TextureGlobe.md#_currentrenderid)
+- [\_disposePhysicsObserver](TextureGlobe.md#_disposephysicsobserver)
+- [\_indexInSceneTransformNodesArray](TextureGlobe.md#_indexinscenetransformnodesarray)
+- [\_internalMetadata](TextureGlobe.md#_internalmetadata)
+- [\_isDirty](TextureGlobe.md#_isdirty)
+- [\_isNode](TextureGlobe.md#_isnode)
+- [\_isWorldMatrixFrozen](TextureGlobe.md#_isworldmatrixfrozen)
+- [\_localMatrix](TextureGlobe.md#_localmatrix)
+- [\_parentContainer](TextureGlobe.md#_parentcontainer)
+- [\_parentNode](TextureGlobe.md#_parentnode)
+- [\_physicsBody](TextureGlobe.md#_physicsbody)
+- [\_poseMatrix](TextureGlobe.md#_posematrix)
+- [\_postMultiplyPivotMatrix](TextureGlobe.md#_postmultiplypivotmatrix)
+- [\_ranges](TextureGlobe.md#_ranges)
+- [\_scaling](TextureGlobe.md#_scaling)
+- [\_scene](TextureGlobe.md#_scene)
+- [\_waitingParentId](TextureGlobe.md#_waitingparentid)
+- [\_waitingParentInstanceIndex](TextureGlobe.md#_waitingparentinstanceindex)
+- [\_waitingParsedUniqueId](TextureGlobe.md#_waitingparseduniqueid)
+- [\_worldMatrix](TextureGlobe.md#_worldmatrix)
+- [\_worldMatrixDeterminant](TextureGlobe.md#_worldmatrixdeterminant)
+- [\_worldMatrixDeterminantIsDirty](TextureGlobe.md#_worldmatrixdeterminantisdirty)
+- [animations](TextureGlobe.md#animations)
 - [container](TextureGlobe.md#container)
 - [context](TextureGlobe.md#context)
 - [diameter](TextureGlobe.md#diameter)
+- [id](TextureGlobe.md#id)
+- [ignoreNonUniformScaling](TextureGlobe.md#ignorenonuniformscaling)
+- [inspectableCustomProperties](TextureGlobe.md#inspectablecustomproperties)
 - [layers](TextureGlobe.md#layers)
 - [lonLatToVector3](TextureGlobe.md#lonlattovector3)
 - [map](TextureGlobe.md#map)
 - [mesh](TextureGlobe.md#mesh)
+- [metadata](TextureGlobe.md#metadata)
 - [name](TextureGlobe.md#name)
+- [onAccessibilityTagChangedObservable](TextureGlobe.md#onaccessibilitytagchangedobservable)
+- [onAfterWorldMatrixUpdateObservable](TextureGlobe.md#onafterworldmatrixupdateobservable)
+- [onDisposeObservable](TextureGlobe.md#ondisposeobservable)
+- [onReady](TextureGlobe.md#onready)
+- [physicsBody](TextureGlobe.md#physicsbody)
+- [reIntegrateRotationIntoRotationQuaternion](TextureGlobe.md#reintegraterotationintorotationquaternion)
+- [reservedDataStore](TextureGlobe.md#reserveddatastore)
 - [resolution](TextureGlobe.md#resolution)
+- [scalingDeterminant](TextureGlobe.md#scalingdeterminant)
 - [scene](TextureGlobe.md#scene)
+- [state](TextureGlobe.md#state)
 - [target](TextureGlobe.md#target)
 - [texture](TextureGlobe.md#texture)
+- [uniqueId](TextureGlobe.md#uniqueid)
 - [view](TextureGlobe.md#view)
+- [BILLBOARDMODE\_ALL](TextureGlobe.md#billboardmode_all)
+- [BILLBOARDMODE\_NONE](TextureGlobe.md#billboardmode_none)
+- [BILLBOARDMODE\_USE\_POSITION](TextureGlobe.md#billboardmode_use_position)
+- [BILLBOARDMODE\_X](TextureGlobe.md#billboardmode_x)
+- [BILLBOARDMODE\_Y](TextureGlobe.md#billboardmode_y)
+- [BILLBOARDMODE\_Z](TextureGlobe.md#billboardmode_z)
+- [BillboardUseParentOrientation](TextureGlobe.md#billboarduseparentorientation)
+- [\_AnimationRangeFactory](TextureGlobe.md#_animationrangefactory)
+
+### Accessors
+
+- [absolutePosition](TextureGlobe.md#absoluteposition)
+- [absoluteRotationQuaternion](TextureGlobe.md#absoluterotationquaternion)
+- [absoluteScaling](TextureGlobe.md#absolutescaling)
+- [accessibilityTag](TextureGlobe.md#accessibilitytag)
+- [animationPropertiesOverride](TextureGlobe.md#animationpropertiesoverride)
+- [behaviors](TextureGlobe.md#behaviors)
+- [billboardMode](TextureGlobe.md#billboardmode)
+- [doNotSerialize](TextureGlobe.md#donotserialize)
+- [forward](TextureGlobe.md#forward)
+- [infiniteDistance](TextureGlobe.md#infinitedistance)
+- [isWorldMatrixFrozen](TextureGlobe.md#isworldmatrixfrozen)
+- [nonUniformScaling](TextureGlobe.md#nonuniformscaling)
+- [onClonedObservable](TextureGlobe.md#onclonedobservable)
+- [onDispose](TextureGlobe.md#ondispose)
+- [onEnabledStateChangedObservable](TextureGlobe.md#onenabledstatechangedobservable)
+- [parent](TextureGlobe.md#parent)
+- [position](TextureGlobe.md#position)
+- [preserveParentRotationForBillboard](TextureGlobe.md#preserveparentrotationforbillboard)
+- [right](TextureGlobe.md#right)
+- [rotation](TextureGlobe.md#rotation)
+- [rotationQuaternion](TextureGlobe.md#rotationquaternion)
+- [scaling](TextureGlobe.md#scaling)
+- [up](TextureGlobe.md#up)
+- [worldMatrixFromCache](TextureGlobe.md#worldmatrixfromcache)
 
 ### Methods
 
+- [\_addToSceneRootNodes](TextureGlobe.md#_addtoscenerootnodes)
+- [\_afterComputeWorldMatrix](TextureGlobe.md#_aftercomputeworldmatrix)
+- [\_getActionManagerForTrigger](TextureGlobe.md#_getactionmanagerfortrigger)
+- [\_getDescendants](TextureGlobe.md#_getdescendants)
+- [\_getEffectiveParent](TextureGlobe.md#_geteffectiveparent)
+- [\_getWorldMatrixDeterminant](TextureGlobe.md#_getworldmatrixdeterminant)
+- [\_initCache](TextureGlobe.md#_initcache)
+- [\_isSynchronized](TextureGlobe.md#_issynchronized)
+- [\_markSyncedWithParent](TextureGlobe.md#_marksyncedwithparent)
+- [\_removeFromSceneRootNodes](TextureGlobe.md#_removefromscenerootnodes)
+- [\_serializeAsParent](TextureGlobe.md#_serializeasparent)
+- [\_setReady](TextureGlobe.md#_setready)
+- [\_syncParentEnabledState](TextureGlobe.md#_syncparentenabledstate)
+- [\_updateCache](TextureGlobe.md#_updatecache)
+- [\_updateNonUniformScalingState](TextureGlobe.md#_updatenonuniformscalingstate)
+- [addBehavior](TextureGlobe.md#addbehavior)
+- [addChild](TextureGlobe.md#addchild)
+- [addRotation](TextureGlobe.md#addrotation)
+- [applyAngularImpulse](TextureGlobe.md#applyangularimpulse)
+- [applyImpulse](TextureGlobe.md#applyimpulse)
+- [attachToBone](TextureGlobe.md#attachtobone)
+- [beginAnimation](TextureGlobe.md#beginanimation)
+- [clone](TextureGlobe.md#clone)
+- [computeWorldMatrix](TextureGlobe.md#computeworldmatrix)
+- [createAnimationRange](TextureGlobe.md#createanimationrange)
 - [createContainer](TextureGlobe.md#createcontainer)
 - [createMesh](TextureGlobe.md#createmesh)
 - [createOLMap](TextureGlobe.md#createolmap)
 - [createScales](TextureGlobe.md#createscales)
 - [createTexture](TextureGlobe.md#createtexture)
+- [deleteAnimationRange](TextureGlobe.md#deleteanimationrange)
+- [detachFromBone](TextureGlobe.md#detachfrombone)
+- [dispose](TextureGlobe.md#dispose)
+- [freezeWorldMatrix](TextureGlobe.md#freezeworldmatrix)
+- [getAbsolutePivotPoint](TextureGlobe.md#getabsolutepivotpoint)
+- [getAbsolutePivotPointToRef](TextureGlobe.md#getabsolutepivotpointtoref)
+- [getAbsolutePosition](TextureGlobe.md#getabsoluteposition)
+- [getAnimationByName](TextureGlobe.md#getanimationbyname)
+- [getAnimationRange](TextureGlobe.md#getanimationrange)
+- [getAnimationRanges](TextureGlobe.md#getanimationranges)
+- [getBehaviorByName](TextureGlobe.md#getbehaviorbyname)
+- [getChildMeshes](TextureGlobe.md#getchildmeshes)
+- [getChildTransformNodes](TextureGlobe.md#getchildtransformnodes)
+- [getChildren](TextureGlobe.md#getchildren)
+- [getClassName](TextureGlobe.md#getclassname)
+- [getDescendants](TextureGlobe.md#getdescendants)
+- [getDirection](TextureGlobe.md#getdirection)
+- [getDirectionToRef](TextureGlobe.md#getdirectiontoref)
+- [getDistanceToCamera](TextureGlobe.md#getdistancetocamera)
+- [getEngine](TextureGlobe.md#getengine)
+- [getHierarchyBoundingVectors](TextureGlobe.md#gethierarchyboundingvectors)
+- [getPhysicsBody](TextureGlobe.md#getphysicsbody)
+- [getPivotMatrix](TextureGlobe.md#getpivotmatrix)
+- [getPivotPoint](TextureGlobe.md#getpivotpoint)
+- [getPivotPointToRef](TextureGlobe.md#getpivotpointtoref)
+- [getPoseMatrix](TextureGlobe.md#getposematrix)
+- [getPositionExpressedInLocalSpace](TextureGlobe.md#getpositionexpressedinlocalspace)
+- [getPositionInCameraSpace](TextureGlobe.md#getpositionincameraspace)
+- [getScene](TextureGlobe.md#getscene)
+- [getWorldMatrix](TextureGlobe.md#getworldmatrix)
+- [instantiateHierarchy](TextureGlobe.md#instantiatehierarchy)
+- [isDescendantOf](TextureGlobe.md#isdescendantof)
+- [isDisposed](TextureGlobe.md#isdisposed)
+- [isEnabled](TextureGlobe.md#isenabled)
+- [isReady](TextureGlobe.md#isready)
+- [isSynchronized](TextureGlobe.md#issynchronized)
+- [isSynchronizedWithParent](TextureGlobe.md#issynchronizedwithparent)
+- [isUsingPivotMatrix](TextureGlobe.md#isusingpivotmatrix)
+- [isUsingPostMultiplyPivotMatrix](TextureGlobe.md#isusingpostmultiplypivotmatrix)
+- [isWorldMatrixCameraDependent](TextureGlobe.md#isworldmatrixcameradependent)
+- [locallyTranslate](TextureGlobe.md#locallytranslate)
+- [lookAt](TextureGlobe.md#lookat)
+- [markAsDirty](TextureGlobe.md#markasdirty)
+- [normalizeToUnitCube](TextureGlobe.md#normalizetounitcube)
+- [registerAfterWorldMatrixUpdate](TextureGlobe.md#registerafterworldmatrixupdate)
+- [removeBehavior](TextureGlobe.md#removebehavior)
+- [removeChild](TextureGlobe.md#removechild)
+- [resetLocalMatrix](TextureGlobe.md#resetlocalmatrix)
+- [rotate](TextureGlobe.md#rotate)
+- [rotateAround](TextureGlobe.md#rotatearound)
+- [serialize](TextureGlobe.md#serialize)
+- [serializeAnimationRanges](TextureGlobe.md#serializeanimationranges)
+- [setAbsolutePosition](TextureGlobe.md#setabsoluteposition)
+- [setDirection](TextureGlobe.md#setdirection)
+- [setEnabled](TextureGlobe.md#setenabled)
+- [setParent](TextureGlobe.md#setparent)
+- [setPivotMatrix](TextureGlobe.md#setpivotmatrix)
+- [setPivotPoint](TextureGlobe.md#setpivotpoint)
+- [setPositionWithLocalVector](TextureGlobe.md#setpositionwithlocalvector)
+- [setPreTransformMatrix](TextureGlobe.md#setpretransformmatrix)
+- [translate](TextureGlobe.md#translate)
+- [unfreezeWorldMatrix](TextureGlobe.md#unfreezeworldmatrix)
+- [unregisterAfterWorldMatrixUpdate](TextureGlobe.md#unregisterafterworldmatrixupdate)
+- [updateCache](TextureGlobe.md#updatecache)
+- [updatePoseMatrix](TextureGlobe.md#updateposematrix)
+- [AddNodeConstructor](TextureGlobe.md#addnodeconstructor)
+- [Construct](TextureGlobe.md#construct)
+- [Parse](TextureGlobe.md#parse)
+- [ParseAnimationRanges](TextureGlobe.md#parseanimationranges)
 
 ## Constructors
 
@@ -53,11 +229,399 @@
 
 [`TextureGlobe`](TextureGlobe.md)
 
+#### Overrides
+
+TransformNode.constructor
+
 #### Defined in
 
-[prefabs/Mapping/textureGlobe.ts:39](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Mapping/textureGlobe.ts#L39)
+[src/prefabs/Mapping/textureGlobe.ts:41](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Mapping/textureGlobe.ts#L41)
 
 ## Properties
+
+### \_accessibilityTag
+
+• `Protected` **\_accessibilityTag**: `IAccessibilityTag`
+
+#### Inherited from
+
+TransformNode.\_accessibilityTag
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:82
+
+___
+
+### \_cache
+
+• **\_cache**: `any`
+
+#### Inherited from
+
+TransformNode.\_cache
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:119
+
+___
+
+### \_childUpdateId
+
+• **\_childUpdateId**: `number`
+
+#### Inherited from
+
+TransformNode.\_childUpdateId
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:109
+
+___
+
+### \_children
+
+• `Protected` **\_children**: `Node`[]
+
+#### Inherited from
+
+TransformNode.\_children
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:122
+
+___
+
+### \_currentRenderId
+
+• **\_currentRenderId**: `number`
+
+#### Inherited from
+
+TransformNode.\_currentRenderId
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:106
+
+___
+
+### \_disposePhysicsObserver
+
+• **\_disposePhysicsObserver**: `Observer`\<`Node`\>
+
+#### Inherited from
+
+TransformNode.\_disposePhysicsObserver
+
+#### Defined in
+
+node_modules/@babylonjs/core/Physics/v2/physicsEngineComponent.d.ts:35
+
+___
+
+### \_indexInSceneTransformNodesArray
+
+• **\_indexInSceneTransformNodesArray**: `number`
+
+#### Inherited from
+
+TransformNode.\_indexInSceneTransformNodesArray
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:112
+
+___
+
+### \_internalMetadata
+
+• **\_internalMetadata**: `any`
+
+#### Inherited from
+
+TransformNode.\_internalMetadata
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:67
+
+___
+
+### \_isDirty
+
+• `Protected` **\_isDirty**: `boolean`
+
+#### Inherited from
+
+TransformNode.\_isDirty
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:24
+
+___
+
+### \_isNode
+
+• `Readonly` **\_isNode**: ``true``
+
+#### Inherited from
+
+TransformNode.\_isNode
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:160
+
+___
+
+### \_isWorldMatrixFrozen
+
+• `Protected` **\_isWorldMatrixFrozen**: `boolean`
+
+#### Inherited from
+
+TransformNode.\_isWorldMatrixFrozen
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:110
+
+___
+
+### \_localMatrix
+
+• **\_localMatrix**: `Matrix`
+
+#### Inherited from
+
+TransformNode.\_localMatrix
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:101
+
+___
+
+### \_parentContainer
+
+• **\_parentContainer**: `AbstractScene`
+
+#### Inherited from
+
+TransformNode.\_parentContainer
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:93
+
+___
+
+### \_parentNode
+
+• `Protected` **\_parentNode**: `Node`
+
+#### Inherited from
+
+TransformNode.\_parentNode
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:120
+
+___
+
+### \_physicsBody
+
+• **\_physicsBody**: `PhysicsBody`
+
+#### Inherited from
+
+TransformNode.\_physicsBody
+
+#### Defined in
+
+node_modules/@babylonjs/core/Physics/v2/physicsEngineComponent.d.ts:14
+
+___
+
+### \_poseMatrix
+
+• **\_poseMatrix**: `Matrix`
+
+#### Inherited from
+
+TransformNode.\_poseMatrix
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:99
+
+___
+
+### \_postMultiplyPivotMatrix
+
+• **\_postMultiplyPivotMatrix**: `boolean`
+
+#### Inherited from
+
+TransformNode.\_postMultiplyPivotMatrix
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:109
+
+___
+
+### \_ranges
+
+• `Protected` **\_ranges**: `Object`
+
+#### Index signature
+
+▪ [name: `string`]: `Nullable`\<`AnimationRange`\>
+
+#### Inherited from
+
+TransformNode.\_ranges
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:98
+
+___
+
+### \_scaling
+
+• `Protected` **\_scaling**: `Vector3`
+
+#### Inherited from
+
+TransformNode.\_scaling
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:52
+
+___
+
+### \_scene
+
+• **\_scene**: `Scene`
+
+#### Inherited from
+
+TransformNode.\_scene
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:117
+
+___
+
+### \_waitingParentId
+
+• **\_waitingParentId**: `string`
+
+#### Inherited from
+
+TransformNode.\_waitingParentId
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:111
+
+___
+
+### \_waitingParentInstanceIndex
+
+• **\_waitingParentInstanceIndex**: `string`
+
+#### Inherited from
+
+TransformNode.\_waitingParentInstanceIndex
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:113
+
+___
+
+### \_waitingParsedUniqueId
+
+• **\_waitingParsedUniqueId**: `number`
+
+#### Inherited from
+
+TransformNode.\_waitingParsedUniqueId
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:115
+
+___
+
+### \_worldMatrix
+
+• **\_worldMatrix**: `Matrix`
+
+#### Inherited from
+
+TransformNode.\_worldMatrix
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:124
+
+___
+
+### \_worldMatrixDeterminant
+
+• **\_worldMatrixDeterminant**: `number`
+
+#### Inherited from
+
+TransformNode.\_worldMatrixDeterminant
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:126
+
+___
+
+### \_worldMatrixDeterminantIsDirty
+
+• **\_worldMatrixDeterminantIsDirty**: `boolean`
+
+#### Inherited from
+
+TransformNode.\_worldMatrixDeterminantIsDirty
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:128
+
+___
+
+### animations
+
+• **animations**: `Animation`[]
+
+Gets a list of Animations associated with the node
+
+#### Inherited from
+
+TransformNode.animations
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:97
+
+___
 
 ### container
 
@@ -65,7 +629,7 @@
 
 #### Defined in
 
-[prefabs/Mapping/textureGlobe.ts:31](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Mapping/textureGlobe.ts#L31)
+[src/prefabs/Mapping/textureGlobe.ts:33](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Mapping/textureGlobe.ts#L33)
 
 ___
 
@@ -75,7 +639,7 @@ ___
 
 #### Defined in
 
-[prefabs/Mapping/textureGlobe.ts:35](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Mapping/textureGlobe.ts#L35)
+[src/prefabs/Mapping/textureGlobe.ts:37](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Mapping/textureGlobe.ts#L37)
 
 ___
 
@@ -85,7 +649,60 @@ ___
 
 #### Defined in
 
-[prefabs/Mapping/textureGlobe.ts:36](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Mapping/textureGlobe.ts#L36)
+[src/prefabs/Mapping/textureGlobe.ts:38](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Mapping/textureGlobe.ts#L38)
+
+___
+
+### id
+
+• **id**: `string`
+
+Gets or sets the id of the node
+
+#### Inherited from
+
+TransformNode.id
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:53
+
+___
+
+### ignoreNonUniformScaling
+
+• **ignoreNonUniformScaling**: `boolean`
+
+Gets or sets a boolean indicating that non uniform scaling (when at least one component is different from others) should be ignored.
+By default the system will update normals to compensate
+
+#### Inherited from
+
+TransformNode.ignoreNonUniformScaling
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:93
+
+___
+
+### inspectableCustomProperties
+
+• **inspectableCustomProperties**: `IInspectable`[]
+
+List of inspectable custom properties (used by the Inspector)
+
+**`See`**
+
+https://doc.babylonjs.com/toolsAndResources/inspector#extensibility
+
+#### Inherited from
+
+TransformNode.inspectableCustomProperties
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:76
 
 ___
 
@@ -95,7 +712,7 @@ ___
 
 #### Defined in
 
-[prefabs/Mapping/textureGlobe.ts:27](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Mapping/textureGlobe.ts#L27)
+[src/prefabs/Mapping/textureGlobe.ts:29](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Mapping/textureGlobe.ts#L29)
 
 ___
 
@@ -105,7 +722,7 @@ ___
 
 #### Defined in
 
-[prefabs/Mapping/textureGlobe.ts:37](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Mapping/textureGlobe.ts#L37)
+[src/prefabs/Mapping/textureGlobe.ts:39](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Mapping/textureGlobe.ts#L39)
 
 ___
 
@@ -115,7 +732,7 @@ ___
 
 #### Defined in
 
-[prefabs/Mapping/textureGlobe.ts:30](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Mapping/textureGlobe.ts#L30)
+[src/prefabs/Mapping/textureGlobe.ts:32](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Mapping/textureGlobe.ts#L32)
 
 ___
 
@@ -125,7 +742,23 @@ ___
 
 #### Defined in
 
-[prefabs/Mapping/textureGlobe.ts:34](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Mapping/textureGlobe.ts#L34)
+[src/prefabs/Mapping/textureGlobe.ts:36](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Mapping/textureGlobe.ts#L36)
+
+___
+
+### metadata
+
+• **metadata**: `any`
+
+Gets or sets an object used to store user defined information for the node
+
+#### Inherited from
+
+TransformNode.metadata
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:65
 
 ___
 
@@ -133,9 +766,139 @@ ___
 
 • **name**: `string`
 
+#### Overrides
+
+TransformNode.name
+
 #### Defined in
 
-[prefabs/Mapping/textureGlobe.ts:25](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Mapping/textureGlobe.ts#L25)
+[src/prefabs/Mapping/textureGlobe.ts:27](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Mapping/textureGlobe.ts#L27)
+
+___
+
+### onAccessibilityTagChangedObservable
+
+• **onAccessibilityTagChangedObservable**: `Observable`\<`IAccessibilityTag`\>
+
+Observable fired when an accessibility tag is changed
+
+#### Inherited from
+
+TransformNode.onAccessibilityTagChangedObservable
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:86
+
+___
+
+### onAfterWorldMatrixUpdateObservable
+
+• **onAfterWorldMatrixUpdateObservable**: `Observable`\<`TransformNode`\>
+
+An event triggered after the world matrix is updated
+
+#### Inherited from
+
+TransformNode.onAfterWorldMatrixUpdateObservable
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:116
+
+___
+
+### onDisposeObservable
+
+• **onDisposeObservable**: `Observable`\<`Node`\>
+
+An event triggered when the mesh is disposed
+
+#### Inherited from
+
+TransformNode.onDisposeObservable
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:164
+
+___
+
+### onReady
+
+• **onReady**: (`node`: `Node`) => `void`
+
+Callback raised when the node is ready to be used
+
+#### Type declaration
+
+▸ (`node`): `void`
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `node` | `Node` |
+
+##### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.onReady
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:104
+
+___
+
+### physicsBody
+
+• **physicsBody**: `PhysicsBody`
+
+**`See`**
+
+#### Inherited from
+
+TransformNode.physicsBody
+
+#### Defined in
+
+node_modules/@babylonjs/core/Physics/v2/physicsEngineComponent.d.ts:18
+
+___
+
+### reIntegrateRotationIntoRotationQuaternion
+
+• **reIntegrateRotationIntoRotationQuaternion**: `boolean`
+
+Gets or sets a boolean indicating that even if rotationQuaternion is defined, you can keep updating rotation property and Babylon.js will just mix both
+
+#### Inherited from
+
+TransformNode.reIntegrateRotationIntoRotationQuaternion
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:97
+
+___
+
+### reservedDataStore
+
+• **reservedDataStore**: `any`
+
+For internal use only. Please do not use.
+
+#### Inherited from
+
+TransformNode.reservedDataStore
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:71
 
 ___
 
@@ -145,7 +908,23 @@ ___
 
 #### Defined in
 
-[prefabs/Mapping/textureGlobe.ts:32](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Mapping/textureGlobe.ts#L32)
+[src/prefabs/Mapping/textureGlobe.ts:34](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Mapping/textureGlobe.ts#L34)
+
+___
+
+### scalingDeterminant
+
+• **scalingDeterminant**: `number`
+
+Multiplication factor on scale x/y/z when computing the world matrix. Eg. for a 1x1x1 cube setting this to 2 will make it a 2x2x2 cube
+
+#### Inherited from
+
+TransformNode.scalingDeterminant
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:82
 
 ___
 
@@ -155,7 +934,23 @@ ___
 
 #### Defined in
 
-[prefabs/Mapping/textureGlobe.ts:26](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Mapping/textureGlobe.ts#L26)
+[src/prefabs/Mapping/textureGlobe.ts:28](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Mapping/textureGlobe.ts#L28)
+
+___
+
+### state
+
+• **state**: `string`
+
+Gets or sets a string used to store user defined state for the node
+
+#### Inherited from
+
+TransformNode.state
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:61
 
 ___
 
@@ -165,7 +960,7 @@ ___
 
 #### Defined in
 
-[prefabs/Mapping/textureGlobe.ts:28](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Mapping/textureGlobe.ts#L28)
+[src/prefabs/Mapping/textureGlobe.ts:30](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Mapping/textureGlobe.ts#L30)
 
 ___
 
@@ -175,7 +970,23 @@ ___
 
 #### Defined in
 
-[prefabs/Mapping/textureGlobe.ts:33](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Mapping/textureGlobe.ts#L33)
+[src/prefabs/Mapping/textureGlobe.ts:35](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Mapping/textureGlobe.ts#L35)
+
+___
+
+### uniqueId
+
+• **uniqueId**: `number`
+
+Gets or sets the unique id of the node
+
+#### Inherited from
+
+TransformNode.uniqueId
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:57
 
 ___
 
@@ -185,9 +996,1495 @@ ___
 
 #### Defined in
 
-[prefabs/Mapping/textureGlobe.ts:29](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Mapping/textureGlobe.ts#L29)
+[src/prefabs/Mapping/textureGlobe.ts:31](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Mapping/textureGlobe.ts#L31)
+
+___
+
+### BILLBOARDMODE\_ALL
+
+▪ `Static` **BILLBOARDMODE\_ALL**: `number`
+
+Object will rotate to face the camera
+
+#### Inherited from
+
+TransformNode.BILLBOARDMODE\_ALL
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:34
+
+___
+
+### BILLBOARDMODE\_NONE
+
+▪ `Static` **BILLBOARDMODE\_NONE**: `number`
+
+Object will not rotate to face the camera
+
+#### Inherited from
+
+TransformNode.BILLBOARDMODE\_NONE
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:18
+
+___
+
+### BILLBOARDMODE\_USE\_POSITION
+
+▪ `Static` **BILLBOARDMODE\_USE\_POSITION**: `number`
+
+Object will rotate to face the camera's position instead of orientation
+
+#### Inherited from
+
+TransformNode.BILLBOARDMODE\_USE\_POSITION
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:38
+
+___
+
+### BILLBOARDMODE\_X
+
+▪ `Static` **BILLBOARDMODE\_X**: `number`
+
+Object will rotate to face the camera but only on the x axis
+
+#### Inherited from
+
+TransformNode.BILLBOARDMODE\_X
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:22
+
+___
+
+### BILLBOARDMODE\_Y
+
+▪ `Static` **BILLBOARDMODE\_Y**: `number`
+
+Object will rotate to face the camera but only on the y axis
+
+#### Inherited from
+
+TransformNode.BILLBOARDMODE\_Y
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:26
+
+___
+
+### BILLBOARDMODE\_Z
+
+▪ `Static` **BILLBOARDMODE\_Z**: `number`
+
+Object will rotate to face the camera but only on the z axis
+
+#### Inherited from
+
+TransformNode.BILLBOARDMODE\_Z
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:30
+
+___
+
+### BillboardUseParentOrientation
+
+▪ `Static` **BillboardUseParentOrientation**: `boolean`
+
+Child transform with Billboard flags should or should not apply parent rotation (default if off)
+
+#### Inherited from
+
+TransformNode.BillboardUseParentOrientation
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:42
+
+___
+
+### \_AnimationRangeFactory
+
+▪ `Static` **\_AnimationRangeFactory**: (`_name`: `string`, `_from`: `number`, `_to`: `number`) => `AnimationRange`
+
+#### Type declaration
+
+▸ (`_name`, `_from`, `_to`): `AnimationRange`
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `_name` | `string` |
+| `_from` | `number` |
+| `_to` | `number` |
+
+##### Returns
+
+`AnimationRange`
+
+#### Inherited from
+
+TransformNode.\_AnimationRangeFactory
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:28
+
+## Accessors
+
+### absolutePosition
+
+• `get` **absolutePosition**(): `Vector3`
+
+Returns the current mesh absolute position.
+Returns a Vector3.
+
+#### Returns
+
+`Vector3`
+
+#### Inherited from
+
+TransformNode.absolutePosition
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:185
+
+___
+
+### absoluteRotationQuaternion
+
+• `get` **absoluteRotationQuaternion**(): `Quaternion`
+
+Returns the current mesh absolute rotation.
+Returns a Quaternion.
+
+#### Returns
+
+`Quaternion`
+
+#### Inherited from
+
+TransformNode.absoluteRotationQuaternion
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:195
+
+___
+
+### absoluteScaling
+
+• `get` **absoluteScaling**(): `Vector3`
+
+Returns the current mesh absolute scaling.
+Returns a Vector3.
+
+#### Returns
+
+`Vector3`
+
+#### Inherited from
+
+TransformNode.absoluteScaling
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:190
+
+___
+
+### accessibilityTag
+
+• `get` **accessibilityTag**(): `IAccessibilityTag`
+
+#### Returns
+
+`IAccessibilityTag`
+
+#### Inherited from
+
+TransformNode.accessibilityTag
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:81
+
+• `set` **accessibilityTag**(`value`): `void`
+
+Gets or sets the accessibility tag to describe the node for accessibility purpose.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `value` | `IAccessibilityTag` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.accessibilityTag
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:80
+
+___
+
+### animationPropertiesOverride
+
+• `get` **animationPropertiesOverride**(): `AnimationPropertiesOverride`
+
+Gets or sets the animation properties override
+
+#### Returns
+
+`AnimationPropertiesOverride`
+
+#### Inherited from
+
+TransformNode.animationPropertiesOverride
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:152
+
+• `set` **animationPropertiesOverride**(`value`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `value` | `AnimationPropertiesOverride` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.animationPropertiesOverride
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:153
+
+___
+
+### behaviors
+
+• `get` **behaviors**(): `Behavior`\<`Node`\>[]
+
+Gets the list of attached behaviors
+
+#### Returns
+
+`Behavior`\<`Node`\>[]
+
+**`See`**
+
+https://doc.babylonjs.com/features/featuresDeepDive/behaviors
+
+#### Inherited from
+
+TransformNode.behaviors
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:215
+
+___
+
+### billboardMode
+
+• `get` **billboardMode**(): `number`
+
+Gets or sets the billboard mode. Default is 0.
+
+| Value | Type | Description |
+| --- | --- | --- |
+| 0 | BILLBOARDMODE_NONE |  |
+| 1 | BILLBOARDMODE_X |  |
+| 2 | BILLBOARDMODE_Y |  |
+| 4 | BILLBOARDMODE_Z |  |
+| 7 | BILLBOARDMODE_ALL |  |
+
+#### Returns
+
+`number`
+
+#### Inherited from
+
+TransformNode.billboardMode
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:69
+
+• `set` **billboardMode**(`value`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `value` | `number` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.billboardMode
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:70
+
+___
+
+### doNotSerialize
+
+• `get` **doNotSerialize**(): `boolean`
+
+Gets or sets a boolean used to define if the node must be serialized
+
+#### Returns
+
+`boolean`
+
+#### Inherited from
+
+TransformNode.doNotSerialize
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:90
+
+• `set` **doNotSerialize**(`value`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `value` | `boolean` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.doNotSerialize
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:91
+
+___
+
+### forward
+
+• `get` **forward**(): `Vector3`
+
+The forward direction of that transform in world space.
+
+#### Returns
+
+`Vector3`
+
+#### Inherited from
+
+TransformNode.forward
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:157
+
+___
+
+### infiniteDistance
+
+• `get` **infiniteDistance**(): `boolean`
+
+Gets or sets the distance of the object to max, often used by skybox
+
+#### Returns
+
+`boolean`
+
+#### Inherited from
+
+TransformNode.infiniteDistance
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:87
+
+• `set` **infiniteDistance**(`value`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `value` | `boolean` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.infiniteDistance
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:88
+
+___
+
+### isWorldMatrixFrozen
+
+• `get` **isWorldMatrixFrozen**(): `boolean`
+
+True if the World matrix has been frozen.
+
+#### Returns
+
+`boolean`
+
+#### Inherited from
+
+TransformNode.isWorldMatrixFrozen
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:241
+
+___
+
+### nonUniformScaling
+
+• `get` **nonUniformScaling**(): `boolean`
+
+True if the scaling property of this object is non uniform eg. (1,2,1)
+
+#### Returns
+
+`boolean`
+
+#### Inherited from
+
+TransformNode.nonUniformScaling
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:372
+
+___
+
+### onClonedObservable
+
+• `get` **onClonedObservable**(): `Observable`\<`Node`\>
+
+An event triggered when the node is cloned
+
+#### Returns
+
+`Observable`\<`Node`\>
+
+#### Inherited from
+
+TransformNode.onClonedObservable
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:177
+
+___
+
+### onDispose
+
+• `set` **onDispose**(`callback`): `void`
+
+Sets a callback that will be raised when the node will be disposed
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `callback` | () => `void` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.onDispose
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:169
+
+___
+
+### onEnabledStateChangedObservable
+
+• `get` **onEnabledStateChangedObservable**(): `Observable`\<`boolean`\>
+
+An event triggered when the enabled state of the node changes
+
+#### Returns
+
+`Observable`\<`boolean`\>
+
+#### Inherited from
+
+TransformNode.onEnabledStateChangedObservable
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:173
+
+___
+
+### parent
+
+• `get` **parent**(): `Node`
+
+#### Returns
+
+`Node`
+
+#### Inherited from
+
+TransformNode.parent
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:139
+
+• `set` **parent**(`parent`): `void`
+
+Gets or sets the parent of the node (without keeping the current position in the scene)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `parent` | `Node` |
+
+#### Returns
+
+`void`
+
+**`See`**
+
+https://doc.babylonjs.com/features/featuresDeepDive/mesh/transforms/parent_pivot/parent
+
+#### Inherited from
+
+TransformNode.parent
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:138
+
+___
+
+### position
+
+• `get` **position**(): `Vector3`
+
+Gets or set the node position (default is (0.0, 0.0, 0.0))
+
+#### Returns
+
+`Vector3`
+
+#### Inherited from
+
+TransformNode.position
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:126
+
+• `set` **position**(`newPosition`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `newPosition` | `Vector3` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.position
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:127
+
+___
+
+### preserveParentRotationForBillboard
+
+• `get` **preserveParentRotationForBillboard**(): `boolean`
+
+Gets or sets a boolean indicating that parent rotation should be preserved when using billboards.
+This could be useful for glTF objects where parent rotation helps converting from right handed to left handed
+
+#### Returns
+
+`boolean`
+
+#### Inherited from
+
+TransformNode.preserveParentRotationForBillboard
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:76
+
+• `set` **preserveParentRotationForBillboard**(`value`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `value` | `boolean` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.preserveParentRotationForBillboard
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:77
+
+___
+
+### right
+
+• `get` **right**(): `Vector3`
+
+The right direction of that transform in world space.
+
+#### Returns
+
+`Vector3`
+
+#### Inherited from
+
+TransformNode.right
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:165
+
+___
+
+### rotation
+
+• `get` **rotation**(): `Vector3`
+
+Gets or sets the rotation property : a Vector3 defining the rotation value in radians around each local axis X, Y, Z  (default is (0.0, 0.0, 0.0)).
+If rotation quaternion is set, this Vector3 will be ignored and copy from the quaternion
+
+#### Returns
+
+`Vector3`
+
+#### Inherited from
+
+TransformNode.rotation
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:141
+
+• `set` **rotation**(`newRotation`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `newRotation` | `Vector3` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.rotation
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:142
+
+___
+
+### rotationQuaternion
+
+• `get` **rotationQuaternion**(): `Quaternion`
+
+Gets or sets the rotation Quaternion property : this a Quaternion object defining the node rotation by using a unit quaternion (undefined by default, but can be null).
+If set, only the rotationQuaternion is then used to compute the node rotation (ie. node.rotation will be ignored)
+
+#### Returns
+
+`Quaternion`
+
+#### Inherited from
+
+TransformNode.rotationQuaternion
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:152
+
+• `set` **rotationQuaternion**(`quaternion`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `quaternion` | `Quaternion` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.rotationQuaternion
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:153
+
+___
+
+### scaling
+
+• `get` **scaling**(): `Vector3`
+
+Gets or sets the scaling property : a Vector3 defining the node scaling along each local axis X, Y, Z (default is (1.0, 1.0, 1.0)).
+
+#### Returns
+
+`Vector3`
+
+#### Inherited from
+
+TransformNode.scaling
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:146
+
+• `set` **scaling**(`newScaling`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `newScaling` | `Vector3` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.scaling
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:147
+
+___
+
+### up
+
+• `get` **up**(): `Vector3`
+
+The up direction of that transform in world space.
+
+#### Returns
+
+`Vector3`
+
+#### Inherited from
+
+TransformNode.up
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:161
+
+___
+
+### worldMatrixFromCache
+
+• `get` **worldMatrixFromCache**(): `Matrix`
+
+Returns directly the latest state of the mesh World matrix.
+A Matrix is returned.
+
+#### Returns
+
+`Matrix`
+
+#### Inherited from
+
+TransformNode.worldMatrixFromCache
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:234
 
 ## Methods
+
+### \_addToSceneRootNodes
+
+▸ **_addToSceneRootNodes**(): `void`
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.\_addToSceneRootNodes
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:145
+
+___
+
+### \_afterComputeWorldMatrix
+
+▸ **_afterComputeWorldMatrix**(): `void`
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.\_afterComputeWorldMatrix
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:462
+
+___
+
+### \_getActionManagerForTrigger
+
+▸ **_getActionManagerForTrigger**(`trigger?`, `_initialCall?`): `AbstractActionManager`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `trigger?` | `number` |
+| `_initialCall?` | `boolean` |
+
+#### Returns
+
+`AbstractActionManager`
+
+#### Inherited from
+
+TransformNode.\_getActionManagerForTrigger
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:244
+
+___
+
+### \_getDescendants
+
+▸ **_getDescendants**(`results`, `directDescendantsOnly?`, `predicate?`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `results` | `Node`[] |
+| `directDescendantsOnly?` | `boolean` |
+| `predicate?` | (`node`: `Node`) => `boolean` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.\_getDescendants
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:293
+
+___
+
+### \_getEffectiveParent
+
+▸ **_getEffectiveParent**(): `Node`
+
+#### Returns
+
+`Node`
+
+#### Inherited from
+
+TransformNode.\_getEffectiveParent
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:443
+
+___
+
+### \_getWorldMatrixDeterminant
+
+▸ **_getWorldMatrixDeterminant**(): `number`
+
+#### Returns
+
+`number`
+
+#### Inherited from
+
+TransformNode.\_getWorldMatrixDeterminant
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:229
+
+___
+
+### \_initCache
+
+▸ **_initCache**(): `void`
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.\_initCache
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:180
+
+___
+
+### \_isSynchronized
+
+▸ **_isSynchronized**(): `boolean`
+
+#### Returns
+
+`boolean`
+
+#### Inherited from
+
+TransformNode.\_isSynchronized
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:178
+
+___
+
+### \_markSyncedWithParent
+
+▸ **_markSyncedWithParent**(): `void`
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.\_markSyncedWithParent
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:252
+
+___
+
+### \_removeFromSceneRootNodes
+
+▸ **_removeFromSceneRootNodes**(): `void`
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.\_removeFromSceneRootNodes
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:147
+
+___
+
+### \_serializeAsParent
+
+▸ **_serializeAsParent**(`serializationObject`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `serializationObject` | `any` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.\_serializeAsParent
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:143
+
+___
+
+### \_setReady
+
+▸ **_setReady**(`state`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `state` | `boolean` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.\_setReady
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:339
+
+___
+
+### \_syncParentEnabledState
+
+▸ **_syncParentEnabledState**(): `void`
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.\_syncParentEnabledState
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:277
+
+___
+
+### \_updateCache
+
+▸ **_updateCache**(`_ignoreParentClass?`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `_ignoreParentClass?` | `boolean` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.\_updateCache
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:248
+
+___
+
+### \_updateNonUniformScalingState
+
+▸ **_updateNonUniformScalingState**(`value`): `boolean`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `value` | `boolean` |
+
+#### Returns
+
+`boolean`
+
+#### Inherited from
+
+TransformNode.\_updateNonUniformScalingState
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:376
+
+___
+
+### addBehavior
+
+▸ **addBehavior**(`behavior`, `attachImmediately?`): `Node`
+
+Attach a behavior to the node
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `behavior` | `Behavior`\<`Node`\> | defines the behavior to attach |
+| `attachImmediately?` | `boolean` | defines that the behavior must be attached even if the scene is still loading |
+
+#### Returns
+
+`Node`
+
+the current Node
+
+**`See`**
+
+https://doc.babylonjs.com/features/featuresDeepDive/behaviors
+
+#### Inherited from
+
+TransformNode.addBehavior
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:203
+
+___
+
+### addChild
+
+▸ **addChild**(`mesh`, `preserveScalingSign?`): `this`
+
+Adds the passed mesh as a child to the current mesh
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `mesh` | `TransformNode` | defines the child mesh |
+| `preserveScalingSign?` | `boolean` | if true, keep scaling sign of child. Otherwise, scaling sign might change. |
+
+#### Returns
+
+`this`
+
+the current mesh
+
+#### Inherited from
+
+TransformNode.addChild
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:360
+
+___
+
+### addRotation
+
+▸ **addRotation**(`x`, `y`, `z`): `TransformNode`
+
+Adds a rotation step to the mesh current rotation.
+x, y, z are Euler angles expressed in radians.
+This methods updates the current mesh rotation, either mesh.rotation, either mesh.rotationQuaternion if it's set.
+This means this rotation is made in the mesh local space only.
+It's useful to set a custom rotation order different from the BJS standard one YXZ.
+Example : this rotates the mesh first around its local X axis, then around its local Z axis, finally around its local Y axis.
+```javascript
+mesh.addRotation(x1, 0, 0).addRotation(0, 0, z2).addRotation(0, 0, y3);
+```
+Note that `addRotation()` accumulates the passed rotation values to the current ones and computes the .rotation or .rotationQuaternion updated values.
+Under the hood, only quaternions are used. So it's a little faster is you use .rotationQuaternion because it doesn't need to translate them back to Euler angles.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `x` | `number` | Rotation to add |
+| `y` | `number` | Rotation to add |
+| `z` | `number` | Rotation to add |
+
+#### Returns
+
+`TransformNode`
+
+the TransformNode.
+
+#### Inherited from
+
+TransformNode.addRotation
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:439
+
+___
+
+### applyAngularImpulse
+
+▸ **applyAngularImpulse**(`angularImpulse`): `TransformNode`
+
+Apply a physic angular impulse to the mesh
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `angularImpulse` | `Vector3` | defines the torque to apply |
+
+#### Returns
+
+`TransformNode`
+
+the current mesh
+
+#### Inherited from
+
+TransformNode.applyAngularImpulse
+
+#### Defined in
+
+node_modules/@babylonjs/core/Physics/v2/physicsEngineComponent.d.ts:33
+
+___
+
+### applyImpulse
+
+▸ **applyImpulse**(`force`, `contactPoint`): `TransformNode`
+
+Apply a physic impulse to the mesh
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `force` | `Vector3` | defines the force to apply |
+| `contactPoint` | `Vector3` | defines where to apply the force |
+
+#### Returns
+
+`TransformNode`
+
+the current mesh
+
+#### Inherited from
+
+TransformNode.applyImpulse
+
+#### Defined in
+
+node_modules/@babylonjs/core/Physics/v2/physicsEngineComponent.d.ts:28
+
+___
+
+### attachToBone
+
+▸ **attachToBone**(`bone`, `affectedTransformNode`): `TransformNode`
+
+Attach the current TransformNode to another TransformNode associated with a bone
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `bone` | `Bone` | Bone affecting the TransformNode |
+| `affectedTransformNode` | `TransformNode` | TransformNode associated with the bone |
+
+#### Returns
+
+`TransformNode`
+
+this object
+
+#### Inherited from
+
+TransformNode.attachToBone
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:383
+
+___
+
+### beginAnimation
+
+▸ **beginAnimation**(`name`, `loop?`, `speedRatio?`, `onAnimationEnd?`): `Animatable`
+
+Will start the animation sequence
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `name` | `string` | defines the range frames for animation sequence |
+| `loop?` | `boolean` | defines if the animation should loop (false by default) |
+| `speedRatio?` | `number` | defines the speed factor in which to run the animation (1 by default) |
+| `onAnimationEnd?` | () => `void` | defines a function to be executed when the animation ended (undefined by default) |
+
+#### Returns
+
+`Animatable`
+
+the object created for this animation. If range does not exist, it will return null
+
+#### Inherited from
+
+TransformNode.beginAnimation
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:386
+
+___
+
+### clone
+
+▸ **clone**(`name`, `newParent`, `doNotCloneChildren?`): `TransformNode`
+
+Clone the current transform node
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `name` | `string` | Name of the new clone |
+| `newParent` | `Node` | New parent for the clone |
+| `doNotCloneChildren?` | `boolean` | Do not clone children hierarchy |
+
+#### Returns
+
+`TransformNode`
+
+the new transform node
+
+#### Inherited from
+
+TransformNode.clone
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:495
+
+___
+
+### computeWorldMatrix
+
+▸ **computeWorldMatrix**(`force?`, `camera?`): `Matrix`
+
+Computes the world matrix of the node
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `force?` | `boolean` | defines if the cache version should be invalidated forcing the world matrix to be created from scratch |
+| `camera?` | `Camera` | defines the camera used if different from the scene active camera (This is used with modes like Billboard or infinite distance) |
+
+#### Returns
+
+`Matrix`
+
+the world matrix
+
+#### Inherited from
+
+TransformNode.computeWorldMatrix
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:456
+
+___
+
+### createAnimationRange
+
+▸ **createAnimationRange**(`name`, `from`, `to`): `void`
+
+Creates an animation range for this node
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `name` | `string` | defines the name of the range |
+| `from` | `number` | defines the starting key |
+| `to` | `number` | defines the end key |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.createAnimationRange
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:352
+
+___
 
 ### createContainer
 
@@ -199,7 +2496,7 @@ ___
 
 #### Defined in
 
-[prefabs/Mapping/textureGlobe.ts:55](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Mapping/textureGlobe.ts#L55)
+[src/prefabs/Mapping/textureGlobe.ts:56](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Mapping/textureGlobe.ts#L56)
 
 ___
 
@@ -213,7 +2510,7 @@ ___
 
 #### Defined in
 
-[prefabs/Mapping/textureGlobe.ts:94](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Mapping/textureGlobe.ts#L94)
+[src/prefabs/Mapping/textureGlobe.ts:95](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Mapping/textureGlobe.ts#L95)
 
 ___
 
@@ -227,7 +2524,7 @@ ___
 
 #### Defined in
 
-[prefabs/Mapping/textureGlobe.ts:66](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Mapping/textureGlobe.ts#L66)
+[src/prefabs/Mapping/textureGlobe.ts:67](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Mapping/textureGlobe.ts#L67)
 
 ___
 
@@ -247,7 +2544,7 @@ ___
 
 #### Defined in
 
-[prefabs/Mapping/textureGlobe.ts:109](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Mapping/textureGlobe.ts#L109)
+[src/prefabs/Mapping/textureGlobe.ts:111](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Mapping/textureGlobe.ts#L111)
 
 ___
 
@@ -261,4 +2558,1960 @@ ___
 
 #### Defined in
 
-[prefabs/Mapping/textureGlobe.ts:76](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Mapping/textureGlobe.ts#L76)
+[src/prefabs/Mapping/textureGlobe.ts:77](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Mapping/textureGlobe.ts#L77)
+
+___
+
+### deleteAnimationRange
+
+▸ **deleteAnimationRange**(`name`, `deleteFrames?`): `void`
+
+Delete a specific animation range
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `name` | `string` | defines the name of the range to delete |
+| `deleteFrames?` | `boolean` | defines if animation frames from the range must be deleted as well |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.deleteAnimationRange
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:358
+
+___
+
+### detachFromBone
+
+▸ **detachFromBone**(`resetToPreviousParent?`): `TransformNode`
+
+Detach the transform node if its associated with a bone
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `resetToPreviousParent?` | `boolean` | Indicates if the parent that was in effect when attachToBone was called should be set back or if we should set parent to null instead (defaults to the latter) |
+
+#### Returns
+
+`TransformNode`
+
+this object
+
+#### Inherited from
+
+TransformNode.detachFromBone
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:389
+
+___
+
+### dispose
+
+▸ **dispose**(`doNotRecurse?`, `disposeMaterialAndTextures?`): `void`
+
+Releases resources associated with this transform node.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `doNotRecurse?` | `boolean` | Set to true to not recurse into each children (recurse into each children by default) |
+| `disposeMaterialAndTextures?` | `boolean` | Set to true to also dispose referenced materials and textures (false by default) |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.dispose
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:522
+
+___
+
+### freezeWorldMatrix
+
+▸ **freezeWorldMatrix**(`newWorldMatrix?`, `decompose?`): `TransformNode`
+
+Prevents the World matrix to be computed any longer
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `newWorldMatrix?` | `Matrix` | defines an optional matrix to use as world matrix |
+| `decompose?` | `boolean` | defines whether to decompose the given newWorldMatrix or directly assign |
+
+#### Returns
+
+`TransformNode`
+
+the TransformNode.
+
+#### Inherited from
+
+TransformNode.freezeWorldMatrix
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:232
+
+___
+
+### getAbsolutePivotPoint
+
+▸ **getAbsolutePivotPoint**(): `Vector3`
+
+Returns a new Vector3 set with the mesh pivot point World coordinates.
+
+#### Returns
+
+`Vector3`
+
+a new Vector3 set with the mesh pivot point World coordinates.
+
+#### Inherited from
+
+TransformNode.getAbsolutePivotPoint
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:328
+
+___
+
+### getAbsolutePivotPointToRef
+
+▸ **getAbsolutePivotPointToRef**(`result`): `TransformNode`
+
+Sets the Vector3 "result" coordinates with the mesh pivot point World coordinates.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `result` | `Vector3` | vector3 to store the result |
+
+#### Returns
+
+`TransformNode`
+
+this TransformNode.
+
+#### Inherited from
+
+TransformNode.getAbsolutePivotPointToRef
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:334
+
+___
+
+### getAbsolutePosition
+
+▸ **getAbsolutePosition**(): `Vector3`
+
+Returns the mesh absolute position in the World.
+
+#### Returns
+
+`Vector3`
+
+a Vector3.
+
+#### Inherited from
+
+TransformNode.getAbsolutePosition
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:246
+
+___
+
+### getAnimationByName
+
+▸ **getAnimationByName**(`name`): `Animation`
+
+Get an animation by name
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `name` | `string` | defines the name of the animation to look for |
+
+#### Returns
+
+`Animation`
+
+null if not found else the requested animation
+
+#### Inherited from
+
+TransformNode.getAnimationByName
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:345
+
+___
+
+### getAnimationRange
+
+▸ **getAnimationRange**(`name`): `AnimationRange`
+
+Get an animation range by name
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `name` | `string` | defines the name of the animation range to look for |
+
+#### Returns
+
+`AnimationRange`
+
+null if not found else the requested animation range
+
+#### Inherited from
+
+TransformNode.getAnimationRange
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:364
+
+___
+
+### getAnimationRanges
+
+▸ **getAnimationRanges**(): `AnimationRange`[]
+
+Gets the list of all animation ranges defined on this node
+
+#### Returns
+
+`AnimationRange`[]
+
+an array
+
+#### Inherited from
+
+TransformNode.getAnimationRanges
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:377
+
+___
+
+### getBehaviorByName
+
+▸ **getBehaviorByName**(`name`): `Behavior`\<`Node`\>
+
+Gets an attached behavior by name
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `name` | `string` | defines the name of the behavior to look for |
+
+#### Returns
+
+`Behavior`\<`Node`\>
+
+null if behavior was not found else the requested behavior
+
+**`See`**
+
+https://doc.babylonjs.com/features/featuresDeepDive/behaviors
+
+#### Inherited from
+
+TransformNode.getBehaviorByName
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:222
+
+___
+
+### getChildMeshes
+
+▸ **getChildMeshes**\<`T`\>(`directDescendantsOnly?`, `predicate?`): `T`[]
+
+Get all child-meshes of this node
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `AbstractMesh` |
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `directDescendantsOnly?` | `boolean` | defines if true only direct descendants of 'this' will be considered, if false direct and also indirect (children of children, an so on in a recursive manner) descendants of 'this' will be considered (Default: false) |
+| `predicate?` | (`node`: `Node`) => node is T | defines an optional predicate that will be called on every evaluated child, the predicate must return true for a given child to be part of the result, otherwise it will be ignored |
+
+#### Returns
+
+`T`[]
+
+an array of AbstractMesh
+
+#### Inherited from
+
+TransformNode.getChildMeshes
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:314
+
+▸ **getChildMeshes**(`directDescendantsOnly?`, `predicate?`): `AbstractMesh`[]
+
+Get all child-meshes of this node
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `directDescendantsOnly?` | `boolean` | defines if true only direct descendants of 'this' will be considered, if false direct and also indirect (children of children, an so on in a recursive manner) descendants of 'this' will be considered (Default: false) |
+| `predicate?` | (`node`: `Node`) => `boolean` | defines an optional predicate that will be called on every evaluated child, the predicate must return true for a given child to be part of the result, otherwise it will be ignored |
+
+#### Returns
+
+`AbstractMesh`[]
+
+an array of AbstractMesh
+
+#### Inherited from
+
+TransformNode.getChildMeshes
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:321
+
+___
+
+### getChildTransformNodes
+
+▸ **getChildTransformNodes**(`directDescendantsOnly?`, `predicate?`): `TransformNode`[]
+
+Get all child-transformNodes of this node
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `directDescendantsOnly?` | `boolean` | defines if true only direct descendants of 'this' will be considered, if false direct and also indirect (children of children, an so on in a recursive manner) descendants of 'this' will be considered |
+| `predicate?` | (`node`: `Node`) => `boolean` | defines an optional predicate that will be called on every evaluated child, the predicate must return true for a given child to be part of the result, otherwise it will be ignored |
+
+#### Returns
+
+`TransformNode`[]
+
+an array of TransformNode
+
+#### Inherited from
+
+TransformNode.getChildTransformNodes
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:516
+
+___
+
+### getChildren
+
+▸ **getChildren**\<`T`\>(`predicate?`, `directDescendantsOnly?`): `T`[]
+
+Get all direct children of this node
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `Node` |
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `predicate?` | (`node`: `Node`) => node is T | defines an optional predicate that will be called on every evaluated child, the predicate must return true for a given child to be part of the result, otherwise it will be ignored |
+| `directDescendantsOnly?` | `boolean` | defines if true only direct descendants of 'this' will be considered, if false direct and also indirect (children of children, an so on in a recursive manner) descendants of 'this' will be considered (Default: true) |
+
+#### Returns
+
+`T`[]
+
+an array of Node
+
+#### Inherited from
+
+TransformNode.getChildren
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:328
+
+▸ **getChildren**(`predicate?`, `directDescendantsOnly?`): `Node`[]
+
+Get all direct children of this node
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `predicate?` | (`node`: `Node`) => `boolean` | defines an optional predicate that will be called on every evaluated child, the predicate must return true for a given child to be part of the result, otherwise it will be ignored |
+| `directDescendantsOnly?` | `boolean` | defines if true only direct descendants of 'this' will be considered, if false direct and also indirect (children of children, an so on in a recursive manner) descendants of 'this' will be considered (Default: true) |
+
+#### Returns
+
+`Node`[]
+
+an array of Node
+
+#### Inherited from
+
+TransformNode.getChildren
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:335
+
+___
+
+### getClassName
+
+▸ **getClassName**(): `string`
+
+Gets a string identifying the name of the class
+
+#### Returns
+
+`string`
+
+"TransformNode" string
+
+#### Inherited from
+
+TransformNode.getClassName
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:122
+
+___
+
+### getDescendants
+
+▸ **getDescendants**\<`T`\>(`directDescendantsOnly?`, `predicate?`): `T`[]
+
+Will return all nodes that have this node as ascendant
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `Node` |
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `directDescendantsOnly?` | `boolean` | defines if true only direct descendants of 'this' will be considered, if false direct and also indirect (children of children, an so on in a recursive manner) descendants of 'this' will be considered |
+| `predicate?` | (`node`: `Node`) => node is T | defines an optional predicate that will be called on every evaluated child, the predicate must return true for a given child to be part of the result, otherwise it will be ignored |
+
+#### Returns
+
+`T`[]
+
+all children nodes of all types
+
+#### Inherited from
+
+TransformNode.getDescendants
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:300
+
+▸ **getDescendants**(`directDescendantsOnly?`, `predicate?`): `Node`[]
+
+Will return all nodes that have this node as ascendant
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `directDescendantsOnly?` | `boolean` | defines if true only direct descendants of 'this' will be considered, if false direct and also indirect (children of children, an so on in a recursive manner) descendants of 'this' will be considered |
+| `predicate?` | (`node`: `Node`) => `boolean` | defines an optional predicate that will be called on every evaluated child, the predicate must return true for a given child to be part of the result, otherwise it will be ignored |
+
+#### Returns
+
+`Node`[]
+
+all children nodes of all types
+
+#### Inherited from
+
+TransformNode.getDescendants
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:307
+
+___
+
+### getDirection
+
+▸ **getDirection**(`localAxis`): `Vector3`
+
+Returns a new Vector3 that is the localAxis, expressed in the mesh local space, rotated like the mesh.
+This Vector3 is expressed in the World space.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `localAxis` | `Vector3` | axis to rotate |
+
+#### Returns
+
+`Vector3`
+
+a new Vector3 that is the localAxis, expressed in the mesh local space, rotated like the mesh.
+
+#### Inherited from
+
+TransformNode.getDirection
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:287
+
+___
+
+### getDirectionToRef
+
+▸ **getDirectionToRef**(`localAxis`, `result`): `TransformNode`
+
+Sets the Vector3 "result" as the rotated Vector3 "localAxis" in the same rotation than the mesh.
+localAxis is expressed in the mesh local space.
+result is computed in the World space from the mesh World matrix.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `localAxis` | `Vector3` | axis to rotate |
+| `result` | `Vector3` | the resulting transformnode |
+
+#### Returns
+
+`TransformNode`
+
+this TransformNode.
+
+#### Inherited from
+
+TransformNode.getDirectionToRef
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:296
+
+___
+
+### getDistanceToCamera
+
+▸ **getDistanceToCamera**(`camera?`): `number`
+
+Returns the distance from the mesh to the active camera
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `camera?` | `Camera` | defines the camera to use |
+
+#### Returns
+
+`number`
+
+the distance
+
+#### Inherited from
+
+TransformNode.getDistanceToCamera
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:487
+
+___
+
+### getEngine
+
+▸ **getEngine**(): `AbstractEngine`
+
+Gets the engine of the node
+
+#### Returns
+
+`AbstractEngine`
+
+a Engine
+
+#### Inherited from
+
+TransformNode.getEngine
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:194
+
+___
+
+### getHierarchyBoundingVectors
+
+▸ **getHierarchyBoundingVectors**(`includeDescendants?`, `predicate?`): `Object`
+
+Return the minimum and maximum world vectors of the entire hierarchy under current node
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `includeDescendants?` | `boolean` | Include bounding info from descendants as well (true by default) |
+| `predicate?` | (`abstractMesh`: `AbstractMesh`) => `boolean` | defines a callback function that can be customize to filter what meshes should be included in the list used to compute the bounding vectors |
+
+#### Returns
+
+`Object`
+
+the new bounding vectors
+
+| Name | Type |
+| :------ | :------ |
+| `max` | `Vector3` |
+| `min` | `Vector3` |
+
+#### Inherited from
+
+TransformNode.getHierarchyBoundingVectors
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:417
+
+___
+
+### getPhysicsBody
+
+▸ **getPhysicsBody**(): `PhysicsBody`
+
+#### Returns
+
+`PhysicsBody`
+
+#### Inherited from
+
+TransformNode.getPhysicsBody
+
+#### Defined in
+
+node_modules/@babylonjs/core/Physics/v2/physicsEngineComponent.d.ts:22
+
+___
+
+### getPivotMatrix
+
+▸ **getPivotMatrix**(): `Matrix`
+
+Returns the mesh pivot matrix.
+Default : Identity.
+
+#### Returns
+
+`Matrix`
+
+the matrix
+
+#### Inherited from
+
+TransformNode.getPivotMatrix
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:214
+
+___
+
+### getPivotPoint
+
+▸ **getPivotPoint**(): `Vector3`
+
+Returns a new Vector3 set with the mesh pivot point coordinates in the local space.
+
+#### Returns
+
+`Vector3`
+
+the pivot point
+
+#### Inherited from
+
+TransformNode.getPivotPoint
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:317
+
+___
+
+### getPivotPointToRef
+
+▸ **getPivotPointToRef**(`result`): `TransformNode`
+
+Sets the passed Vector3 "result" with the coordinates of the mesh pivot point in the local space.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `result` | `Vector3` | the vector3 to store the result |
+
+#### Returns
+
+`TransformNode`
+
+this TransformNode.
+
+#### Inherited from
+
+TransformNode.getPivotPointToRef
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:323
+
+___
+
+### getPoseMatrix
+
+▸ **getPoseMatrix**(): `Matrix`
+
+Returns the mesh Pose matrix.
+
+#### Returns
+
+`Matrix`
+
+the pose matrix
+
+#### Inherited from
+
+TransformNode.getPoseMatrix
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:176
+
+___
+
+### getPositionExpressedInLocalSpace
+
+▸ **getPositionExpressedInLocalSpace**(): `Vector3`
+
+Returns the mesh position in the local space from the current World matrix values.
+
+#### Returns
+
+`Vector3`
+
+a new Vector3.
+
+#### Inherited from
+
+TransformNode.getPositionExpressedInLocalSpace
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:263
+
+___
+
+### getPositionInCameraSpace
+
+▸ **getPositionInCameraSpace**(`camera?`): `Vector3`
+
+Gets the position of the current mesh in camera space
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `camera?` | `Camera` | defines the camera to use |
+
+#### Returns
+
+`Vector3`
+
+a position
+
+#### Inherited from
+
+TransformNode.getPositionInCameraSpace
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:481
+
+___
+
+### getScene
+
+▸ **getScene**(): `Scene`
+
+Gets the scene of the node
+
+#### Returns
+
+`Scene`
+
+a scene
+
+#### Inherited from
+
+TransformNode.getScene
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:189
+
+___
+
+### getWorldMatrix
+
+▸ **getWorldMatrix**(): `Matrix`
+
+Returns the latest update of the World matrix
+
+#### Returns
+
+`Matrix`
+
+a Matrix
+
+#### Inherited from
+
+TransformNode.getWorldMatrix
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:227
+
+___
+
+### instantiateHierarchy
+
+▸ **instantiateHierarchy**(`newParent?`, `options?`, `onNewNodeCreated?`): `TransformNode`
+
+Instantiate (when possible) or clone that node with its hierarchy
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `newParent?` | `TransformNode` | defines the new parent to use for the instance (or clone) |
+| `options?` | `Object` | defines options to configure how copy is done |
+| `options.doNotInstantiate` | `boolean` \| (`node`: `TransformNode`) => `boolean` | defines if the model must be instantiated or just cloned |
+| `onNewNodeCreated?` | (`source`: `TransformNode`, `clone`: `TransformNode`) => `void` | defines an option callback to call when a clone or an instance is created |
+
+#### Returns
+
+`TransformNode`
+
+an instance (or a clone) of the current node with its hierarchy
+
+#### Inherited from
+
+TransformNode.instantiateHierarchy
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:223
+
+___
+
+### isDescendantOf
+
+▸ **isDescendantOf**(`ancestor`): `boolean`
+
+Is this node a descendant of the given node?
+The function will iterate up the hierarchy until the ancestor was found or no more parents defined
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `ancestor` | `Node` | defines the parent node to inspect |
+
+#### Returns
+
+`boolean`
+
+a boolean indicating if this node is a descendant of the given node
+
+#### Inherited from
+
+TransformNode.isDescendantOf
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:289
+
+___
+
+### isDisposed
+
+▸ **isDisposed**(): `boolean`
+
+Gets a boolean indicating if the node has been disposed
+
+#### Returns
+
+`boolean`
+
+true if the node was disposed
+
+#### Inherited from
+
+TransformNode.isDisposed
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:133
+
+___
+
+### isEnabled
+
+▸ **isEnabled**(`checkAncestors?`): `boolean`
+
+Is this node enabled?
+If the node has a parent, all ancestors will be checked and false will be returned if any are false (not enabled), otherwise will return true
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `checkAncestors?` | `boolean` | indicates if this method should check the ancestors. The default is to check the ancestors. If set to false, the method will return the value of this node without checking ancestors |
+
+#### Returns
+
+`boolean`
+
+whether this node (and its parent) is enabled
+
+#### Inherited from
+
+TransformNode.isEnabled
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:275
+
+___
+
+### isReady
+
+▸ **isReady**(`_completeCheck?`): `boolean`
+
+Is this node ready to be used/rendered
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `_completeCheck?` | `boolean` | defines if a complete check (including materials and lights) has to be done (false by default) |
+
+#### Returns
+
+`boolean`
+
+true if the node is ready
+
+#### Inherited from
+
+TransformNode.isReady
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:262
+
+___
+
+### isSynchronized
+
+▸ **isSynchronized**(): `boolean`
+
+#### Returns
+
+`boolean`
+
+#### Inherited from
+
+TransformNode.isSynchronized
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:256
+
+___
+
+### isSynchronizedWithParent
+
+▸ **isSynchronizedWithParent**(): `boolean`
+
+#### Returns
+
+`boolean`
+
+#### Inherited from
+
+TransformNode.isSynchronizedWithParent
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:254
+
+___
+
+### isUsingPivotMatrix
+
+▸ **isUsingPivotMatrix**(): `boolean`
+
+return true if a pivot has been set
+
+#### Returns
+
+`boolean`
+
+true if a pivot matrix is used
+
+#### Inherited from
+
+TransformNode.isUsingPivotMatrix
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:132
+
+___
+
+### isUsingPostMultiplyPivotMatrix
+
+▸ **isUsingPostMultiplyPivotMatrix**(): `boolean`
+
+#### Returns
+
+`boolean`
+
+true if pivot matrix must be cancelled in the world matrix. When this parameter is set to true (default), the inverse of the pivot matrix is also applied at the end to cancel the transformation effect.
+
+#### Inherited from
+
+TransformNode.isUsingPostMultiplyPivotMatrix
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:136
+
+___
+
+### isWorldMatrixCameraDependent
+
+▸ **isWorldMatrixCameraDependent**(): `boolean`
+
+Returns whether the transform node world matrix computation needs the camera information to be computed.
+This is the case when the node is a billboard or has an infinite distance for instance.
+
+#### Returns
+
+`boolean`
+
+true if the world matrix computation needs the camera information to be computed
+
+#### Inherited from
+
+TransformNode.isWorldMatrixCameraDependent
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:449
+
+___
+
+### locallyTranslate
+
+▸ **locallyTranslate**(`vector3`): `TransformNode`
+
+Translates the mesh along the passed Vector3 in its local space.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `vector3` | `Vector3` | the distance to translate in localspace |
+
+#### Returns
+
+`TransformNode`
+
+the TransformNode.
+
+#### Inherited from
+
+TransformNode.locallyTranslate
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:269
+
+___
+
+### lookAt
+
+▸ **lookAt**(`targetPoint`, `yawCor?`, `pitchCor?`, `rollCor?`, `space?`): `TransformNode`
+
+Orients a mesh towards a target point. Mesh must be drawn facing user.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `targetPoint` | `Vector3` | the position (must be in same space as current mesh) to look at |
+| `yawCor?` | `number` | optional yaw (y-axis) correction in radians |
+| `pitchCor?` | `number` | optional pitch (x-axis) correction in radians |
+| `rollCor?` | `number` | optional roll (z-axis) correction in radians |
+| `space?` | `Space` | the chosen space of the target |
+
+#### Returns
+
+`TransformNode`
+
+the TransformNode.
+
+#### Inherited from
+
+TransformNode.lookAt
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:280
+
+___
+
+### markAsDirty
+
+▸ **markAsDirty**(`property?`): `Node`
+
+Flag the transform node as dirty (Forcing it to update everything)
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `property?` | `string` | if set to "rotation" the objects rotationQuaternion will be set to null |
+
+#### Returns
+
+`Node`
+
+this  node
+
+#### Inherited from
+
+TransformNode.markAsDirty
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:340
+
+___
+
+### normalizeToUnitCube
+
+▸ **normalizeToUnitCube**(`includeDescendants?`, `ignoreRotation?`, `predicate?`): `TransformNode`
+
+Uniformly scales the mesh to fit inside of a unit cube (1 X 1 X 1 units)
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `includeDescendants?` | `boolean` | Use the hierarchy's bounding box instead of the mesh's bounding box. Default is false |
+| `ignoreRotation?` | `boolean` | ignore rotation when computing the scale (ie. object will be axis aligned). Default is false |
+| `predicate?` | (`node`: `AbstractMesh`) => `boolean` | predicate that is passed in to getHierarchyBoundingVectors when selecting which object should be included when scaling |
+
+#### Returns
+
+`TransformNode`
+
+the current mesh
+
+#### Inherited from
+
+TransformNode.normalizeToUnitCube
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:530
+
+___
+
+### registerAfterWorldMatrixUpdate
+
+▸ **registerAfterWorldMatrixUpdate**(`func`): `TransformNode`
+
+If you'd like to be called back after the mesh position, rotation or scaling has been updated.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `func` | (`mesh`: `TransformNode`) => `void` | callback function to add |
+
+#### Returns
+
+`TransformNode`
+
+the TransformNode.
+
+#### Inherited from
+
+TransformNode.registerAfterWorldMatrixUpdate
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:469
+
+___
+
+### removeBehavior
+
+▸ **removeBehavior**(`behavior`): `Node`
+
+Remove an attached behavior
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `behavior` | `Behavior`\<`Node`\> | defines the behavior to attach |
+
+#### Returns
+
+`Node`
+
+the current Node
+
+**`See`**
+
+https://doc.babylonjs.com/features/featuresDeepDive/behaviors
+
+#### Inherited from
+
+TransformNode.removeBehavior
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:210
+
+___
+
+### removeChild
+
+▸ **removeChild**(`mesh`, `preserveScalingSign?`): `this`
+
+Removes the passed mesh from the current mesh children list
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `mesh` | `TransformNode` | defines the child mesh |
+| `preserveScalingSign?` | `boolean` | if true, keep scaling sign of child. Otherwise, scaling sign might change. |
+
+#### Returns
+
+`this`
+
+the current mesh
+
+#### Inherited from
+
+TransformNode.removeChild
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:367
+
+___
+
+### resetLocalMatrix
+
+▸ **resetLocalMatrix**(`independentOfChildren?`): `void`
+
+Resets this nodeTransform's local matrix to Matrix.Identity().
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `independentOfChildren?` | `boolean` | indicates if all child nodeTransform's world-space transform should be preserved. |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.resetLocalMatrix
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:461
+
+___
+
+### rotate
+
+▸ **rotate**(`axis`, `amount`, `space?`): `TransformNode`
+
+Rotates the mesh around the axis vector for the passed angle (amount) expressed in radians, in the given space.
+space (default LOCAL) can be either Space.LOCAL, either Space.WORLD.
+Note that the property `rotationQuaternion` is then automatically updated and the property `rotation` is set to (0,0,0) and no longer used.
+The passed axis is also normalized.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `axis` | `Vector3` | the axis to rotate around |
+| `amount` | `number` | the amount to rotate in radians |
+| `space?` | `Space` | Space to rotate in (Default: local) |
+
+#### Returns
+
+`TransformNode`
+
+the TransformNode.
+
+#### Inherited from
+
+TransformNode.rotate
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:401
+
+___
+
+### rotateAround
+
+▸ **rotateAround**(`point`, `axis`, `amount`): `TransformNode`
+
+Rotates the mesh around the axis vector for the passed angle (amount) expressed in radians, in world space.
+Note that the property `rotationQuaternion` is then automatically updated and the property `rotation` is set to (0,0,0) and no longer used.
+The passed axis is also normalized. .
+Method is based on http://www.euclideanspace.com/maths/geometry/affine/aroundPoint/index.htm
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `point` | `Vector3` | the point to rotate around |
+| `axis` | `Vector3` | the axis to rotate around |
+| `amount` | `number` | the amount to rotate in radians |
+
+#### Returns
+
+`TransformNode`
+
+the TransformNode
+
+#### Inherited from
+
+TransformNode.rotateAround
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:412
+
+___
+
+### serialize
+
+▸ **serialize**(`currentSerializationObject?`): `any`
+
+Serializes the objects information.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `currentSerializationObject?` | `any` | defines the object to serialize in |
+
+#### Returns
+
+`any`
+
+the serialized object
+
+#### Inherited from
+
+TransformNode.serialize
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:501
+
+___
+
+### serializeAnimationRanges
+
+▸ **serializeAnimationRanges**(): `any`
+
+Serialize animation ranges into a JSON compatible object
+
+#### Returns
+
+`any`
+
+serialization object
+
+#### Inherited from
+
+TransformNode.serializeAnimationRanges
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:391
+
+___
+
+### setAbsolutePosition
+
+▸ **setAbsolutePosition**(`absolutePosition`): `TransformNode`
+
+Sets the mesh absolute position in the World from a Vector3 or an Array(3).
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `absolutePosition` | `Vector3` | the absolute position to set |
+
+#### Returns
+
+`TransformNode`
+
+the TransformNode.
+
+#### Inherited from
+
+TransformNode.setAbsolutePosition
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:252
+
+___
+
+### setDirection
+
+▸ **setDirection**(`localAxis`, `yawCor?`, `pitchCor?`, `rollCor?`): `TransformNode`
+
+Sets this transform node rotation to the given local axis.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `localAxis` | `Vector3` | the axis in local space |
+| `yawCor?` | `number` | optional yaw (y-axis) correction in radians |
+| `pitchCor?` | `number` | optional pitch (x-axis) correction in radians |
+| `rollCor?` | `number` | optional roll (z-axis) correction in radians |
+
+#### Returns
+
+`TransformNode`
+
+this TransformNode
+
+#### Inherited from
+
+TransformNode.setDirection
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:305
+
+___
+
+### setEnabled
+
+▸ **setEnabled**(`value`): `void`
+
+Set the enabled state of this node
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `value` | `boolean` | defines the new enabled state |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.setEnabled
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:282
+
+___
+
+### setParent
+
+▸ **setParent**(`node`, `preserveScalingSign?`, `updatePivot?`): `TransformNode`
+
+Defines the passed node as the parent of the current node.
+The node will remain exactly where it is and its position / rotation will be updated accordingly.
+Note that if the mesh has a pivot matrix / point defined it will be applied after the parent was updated.
+In that case the node will not remain in the same space as it is, as the pivot will be applied.
+To avoid this, you can set updatePivot to true and the pivot will be updated to identity
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `node` | `Node` | the node ot set as the parent |
+| `preserveScalingSign?` | `boolean` | if true, keep scaling sign of child. Otherwise, scaling sign might change. |
+| `updatePivot?` | `boolean` | if true, update the pivot matrix to keep the node in the same space as before |
+
+#### Returns
+
+`TransformNode`
+
+this TransformNode.
+
+**`See`**
+
+https://doc.babylonjs.com/features/featuresDeepDive/mesh/transforms/parent_pivot/parent
+
+#### Inherited from
+
+TransformNode.setParent
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:353
+
+___
+
+### setPivotMatrix
+
+▸ **setPivotMatrix**(`matrix`, `postMultiplyPivotMatrix?`): `TransformNode`
+
+Sets a new pivot matrix to the current node
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `matrix` | `DeepImmutableObject`\<`Matrix`\> | defines the new pivot matrix to use |
+| `postMultiplyPivotMatrix?` | `boolean` | defines if the pivot matrix must be cancelled in the world matrix. When this parameter is set to true (default), the inverse of the pivot matrix is also applied at the end to cancel the transformation effect |
+
+#### Returns
+
+`TransformNode`
+
+the current TransformNode
+
+#### Inherited from
+
+TransformNode.setPivotMatrix
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:208
+
+___
+
+### setPivotPoint
+
+▸ **setPivotPoint**(`point`, `space?`): `TransformNode`
+
+Sets a new pivot point to the current node
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `point` | `Vector3` | defines the new pivot point to use |
+| `space?` | `Space` | defines if the point is in world or local space (local by default) |
+
+#### Returns
+
+`TransformNode`
+
+the current TransformNode
+
+#### Inherited from
+
+TransformNode.setPivotPoint
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:312
+
+___
+
+### setPositionWithLocalVector
+
+▸ **setPositionWithLocalVector**(`vector3`): `TransformNode`
+
+Sets the mesh position in its local space.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `vector3` | `Vector3` | the position to set in localspace |
+
+#### Returns
+
+`TransformNode`
+
+the TransformNode.
+
+#### Inherited from
+
+TransformNode.setPositionWithLocalVector
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:258
+
+___
+
+### setPreTransformMatrix
+
+▸ **setPreTransformMatrix**(`matrix`): `TransformNode`
+
+Sets a new matrix to apply before all other transformation
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `matrix` | `Matrix` | defines the transform matrix |
+
+#### Returns
+
+`TransformNode`
+
+the current TransformNode
+
+#### Inherited from
+
+TransformNode.setPreTransformMatrix
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:201
+
+___
+
+### translate
+
+▸ **translate**(`axis`, `distance`, `space?`): `TransformNode`
+
+Translates the mesh along the axis vector for the passed distance in the given space.
+space (default LOCAL) can be either Space.LOCAL, either Space.WORLD.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `axis` | `Vector3` | the axis to translate in |
+| `distance` | `number` | the distance to translate |
+| `space?` | `Space` | Space to rotate in (Default: local) |
+
+#### Returns
+
+`TransformNode`
+
+the TransformNode.
+
+#### Inherited from
+
+TransformNode.translate
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:421
+
+___
+
+### unfreezeWorldMatrix
+
+▸ **unfreezeWorldMatrix**(): `this`
+
+Allows back the World matrix computation.
+
+#### Returns
+
+`this`
+
+the TransformNode.
+
+#### Inherited from
+
+TransformNode.unfreezeWorldMatrix
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:237
+
+___
+
+### unregisterAfterWorldMatrixUpdate
+
+▸ **unregisterAfterWorldMatrixUpdate**(`func`): `TransformNode`
+
+Removes a registered callback function.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `func` | (`mesh`: `TransformNode`) => `void` | callback function to remove |
+
+#### Returns
+
+`TransformNode`
+
+the TransformNode.
+
+#### Inherited from
+
+TransformNode.unregisterAfterWorldMatrixUpdate
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:475
+
+___
+
+### updateCache
+
+▸ **updateCache**(`force?`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `force?` | `boolean` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.updateCache
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:240
+
+___
+
+### updatePoseMatrix
+
+▸ **updatePoseMatrix**(`matrix`): `TransformNode`
+
+Copies the parameter passed Matrix into the mesh Pose matrix.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `matrix` | `Matrix` | the matrix to copy the pose from |
+
+#### Returns
+
+`TransformNode`
+
+this TransformNode.
+
+#### Inherited from
+
+TransformNode.updatePoseMatrix
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:171
+
+___
+
+### AddNodeConstructor
+
+▸ **AddNodeConstructor**(`type`, `constructorFunc`): `void`
+
+Add a new node constructor
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `type` | `string` | defines the type name of the node to construct |
+| `constructorFunc` | `NodeConstructor` | defines the constructor function |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.AddNodeConstructor
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:35
+
+___
+
+### Construct
+
+▸ **Construct**(`type`, `name`, `scene`, `options?`): () => `Node`
+
+Returns a node constructor based on type name
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `type` | `string` | defines the type name |
+| `name` | `string` | defines the new node name |
+| `scene` | `Scene` | defines the hosting scene |
+| `options?` | `any` | defines optional options to transmit to constructors |
+
+#### Returns
+
+`fn`
+
+the new constructor or null
+
+▸ (): `Node`
+
+##### Returns
+
+`Node`
+
+#### Inherited from
+
+TransformNode.Construct
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:44
+
+___
+
+### Parse
+
+▸ **Parse**(`parsedTransformNode`, `scene`, `rootUrl`): `TransformNode`
+
+Returns a new TransformNode object parsed from the source provided.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `parsedTransformNode` | `any` | is the source. |
+| `scene` | `Scene` | the scene the object belongs to |
+| `rootUrl` | `string` | is a string, it's the root URL to prefix the `delayLoadingFile` property with |
+
+#### Returns
+
+`TransformNode`
+
+a new TransformNode object parsed from the source provided.
+
+#### Inherited from
+
+TransformNode.Parse
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:509
+
+___
+
+### ParseAnimationRanges
+
+▸ **ParseAnimationRanges**(`node`, `parsedNode`, `_scene`): `void`
+
+Parse animation range data from a serialization object and store them into a given node
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `node` | `Node` | defines where to store the animation ranges |
+| `parsedNode` | `any` | defines the serialization object to read data from |
+| `_scene` | `Scene` | defines the hosting scene |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.ParseAnimationRanges
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:410

--- a/docs/api/classes/TextureMap.md
+++ b/docs/api/classes/TextureMap.md
@@ -2,6 +2,12 @@
 
 # Class: TextureMap
 
+## Hierarchy
+
+- `TransformNode`
+
+  ↳ **`TextureMap`**
+
 ## Table of contents
 
 ### Constructors
@@ -10,29 +16,199 @@
 
 ### Properties
 
+- [\_accessibilityTag](TextureMap.md#_accessibilitytag)
+- [\_cache](TextureMap.md#_cache)
+- [\_childUpdateId](TextureMap.md#_childupdateid)
+- [\_children](TextureMap.md#_children)
+- [\_currentRenderId](TextureMap.md#_currentrenderid)
+- [\_disposePhysicsObserver](TextureMap.md#_disposephysicsobserver)
+- [\_indexInSceneTransformNodesArray](TextureMap.md#_indexinscenetransformnodesarray)
+- [\_internalMetadata](TextureMap.md#_internalmetadata)
+- [\_isDirty](TextureMap.md#_isdirty)
+- [\_isNode](TextureMap.md#_isnode)
+- [\_isWorldMatrixFrozen](TextureMap.md#_isworldmatrixfrozen)
+- [\_localMatrix](TextureMap.md#_localmatrix)
+- [\_parentContainer](TextureMap.md#_parentcontainer)
+- [\_parentNode](TextureMap.md#_parentnode)
+- [\_physicsBody](TextureMap.md#_physicsbody)
+- [\_poseMatrix](TextureMap.md#_posematrix)
+- [\_postMultiplyPivotMatrix](TextureMap.md#_postmultiplypivotmatrix)
+- [\_ranges](TextureMap.md#_ranges)
+- [\_scaling](TextureMap.md#_scaling)
+- [\_scene](TextureMap.md#_scene)
+- [\_waitingParentId](TextureMap.md#_waitingparentid)
+- [\_waitingParentInstanceIndex](TextureMap.md#_waitingparentinstanceindex)
+- [\_waitingParsedUniqueId](TextureMap.md#_waitingparseduniqueid)
+- [\_worldMatrix](TextureMap.md#_worldmatrix)
+- [\_worldMatrixDeterminant](TextureMap.md#_worldmatrixdeterminant)
+- [\_worldMatrixDeterminantIsDirty](TextureMap.md#_worldmatrixdeterminantisdirty)
+- [animations](TextureMap.md#animations)
 - [container](TextureMap.md#container)
 - [context](TextureMap.md#context)
+- [id](TextureMap.md#id)
+- [ignoreNonUniformScaling](TextureMap.md#ignorenonuniformscaling)
+- [inspectableCustomProperties](TextureMap.md#inspectablecustomproperties)
 - [layers](TextureMap.md#layers)
 - [map](TextureMap.md#map)
 - [mesh](TextureMap.md#mesh)
+- [metadata](TextureMap.md#metadata)
 - [name](TextureMap.md#name)
+- [onAccessibilityTagChangedObservable](TextureMap.md#onaccessibilitytagchangedobservable)
+- [onAfterWorldMatrixUpdateObservable](TextureMap.md#onafterworldmatrixupdateobservable)
+- [onDisposeObservable](TextureMap.md#ondisposeobservable)
+- [onReady](TextureMap.md#onready)
+- [physicsBody](TextureMap.md#physicsbody)
+- [reIntegrateRotationIntoRotationQuaternion](TextureMap.md#reintegraterotationintorotationquaternion)
+- [reservedDataStore](TextureMap.md#reserveddatastore)
 - [resolution](TextureMap.md#resolution)
 - [scaleLat](TextureMap.md#scalelat)
 - [scaleLon](TextureMap.md#scalelon)
+- [scalingDeterminant](TextureMap.md#scalingdeterminant)
 - [scene](TextureMap.md#scene)
 - [size](TextureMap.md#size)
+- [state](TextureMap.md#state)
 - [target](TextureMap.md#target)
 - [texture](TextureMap.md#texture)
+- [uniqueId](TextureMap.md#uniqueid)
 - [view](TextureMap.md#view)
+- [BILLBOARDMODE\_ALL](TextureMap.md#billboardmode_all)
+- [BILLBOARDMODE\_NONE](TextureMap.md#billboardmode_none)
+- [BILLBOARDMODE\_USE\_POSITION](TextureMap.md#billboardmode_use_position)
+- [BILLBOARDMODE\_X](TextureMap.md#billboardmode_x)
+- [BILLBOARDMODE\_Y](TextureMap.md#billboardmode_y)
+- [BILLBOARDMODE\_Z](TextureMap.md#billboardmode_z)
+- [BillboardUseParentOrientation](TextureMap.md#billboarduseparentorientation)
+- [\_AnimationRangeFactory](TextureMap.md#_animationrangefactory)
+
+### Accessors
+
+- [absolutePosition](TextureMap.md#absoluteposition)
+- [absoluteRotationQuaternion](TextureMap.md#absoluterotationquaternion)
+- [absoluteScaling](TextureMap.md#absolutescaling)
+- [accessibilityTag](TextureMap.md#accessibilitytag)
+- [animationPropertiesOverride](TextureMap.md#animationpropertiesoverride)
+- [behaviors](TextureMap.md#behaviors)
+- [billboardMode](TextureMap.md#billboardmode)
+- [doNotSerialize](TextureMap.md#donotserialize)
+- [forward](TextureMap.md#forward)
+- [infiniteDistance](TextureMap.md#infinitedistance)
+- [isWorldMatrixFrozen](TextureMap.md#isworldmatrixfrozen)
+- [nonUniformScaling](TextureMap.md#nonuniformscaling)
+- [onClonedObservable](TextureMap.md#onclonedobservable)
+- [onDispose](TextureMap.md#ondispose)
+- [onEnabledStateChangedObservable](TextureMap.md#onenabledstatechangedobservable)
+- [parent](TextureMap.md#parent)
+- [position](TextureMap.md#position)
+- [preserveParentRotationForBillboard](TextureMap.md#preserveparentrotationforbillboard)
+- [right](TextureMap.md#right)
+- [rotation](TextureMap.md#rotation)
+- [rotationQuaternion](TextureMap.md#rotationquaternion)
+- [scaling](TextureMap.md#scaling)
+- [up](TextureMap.md#up)
+- [worldMatrixFromCache](TextureMap.md#worldmatrixfromcache)
 
 ### Methods
 
+- [\_addToSceneRootNodes](TextureMap.md#_addtoscenerootnodes)
+- [\_afterComputeWorldMatrix](TextureMap.md#_aftercomputeworldmatrix)
+- [\_getActionManagerForTrigger](TextureMap.md#_getactionmanagerfortrigger)
+- [\_getDescendants](TextureMap.md#_getdescendants)
+- [\_getEffectiveParent](TextureMap.md#_geteffectiveparent)
+- [\_getWorldMatrixDeterminant](TextureMap.md#_getworldmatrixdeterminant)
+- [\_initCache](TextureMap.md#_initcache)
+- [\_isSynchronized](TextureMap.md#_issynchronized)
+- [\_markSyncedWithParent](TextureMap.md#_marksyncedwithparent)
+- [\_removeFromSceneRootNodes](TextureMap.md#_removefromscenerootnodes)
+- [\_serializeAsParent](TextureMap.md#_serializeasparent)
+- [\_setReady](TextureMap.md#_setready)
+- [\_syncParentEnabledState](TextureMap.md#_syncparentenabledstate)
+- [\_updateCache](TextureMap.md#_updatecache)
+- [\_updateNonUniformScalingState](TextureMap.md#_updatenonuniformscalingstate)
+- [addBehavior](TextureMap.md#addbehavior)
+- [addChild](TextureMap.md#addchild)
+- [addRotation](TextureMap.md#addrotation)
+- [applyAngularImpulse](TextureMap.md#applyangularimpulse)
+- [applyImpulse](TextureMap.md#applyimpulse)
+- [attachToBone](TextureMap.md#attachtobone)
+- [beginAnimation](TextureMap.md#beginanimation)
+- [clone](TextureMap.md#clone)
+- [computeWorldMatrix](TextureMap.md#computeworldmatrix)
+- [createAnimationRange](TextureMap.md#createanimationrange)
 - [createContainer](TextureMap.md#createcontainer)
 - [createMesh](TextureMap.md#createmesh)
 - [createOLMap](TextureMap.md#createolmap)
 - [createScales](TextureMap.md#createscales)
 - [createTexture](TextureMap.md#createtexture)
+- [deleteAnimationRange](TextureMap.md#deleteanimationrange)
+- [detachFromBone](TextureMap.md#detachfrombone)
+- [dispose](TextureMap.md#dispose)
+- [freezeWorldMatrix](TextureMap.md#freezeworldmatrix)
+- [getAbsolutePivotPoint](TextureMap.md#getabsolutepivotpoint)
+- [getAbsolutePivotPointToRef](TextureMap.md#getabsolutepivotpointtoref)
+- [getAbsolutePosition](TextureMap.md#getabsoluteposition)
+- [getAnimationByName](TextureMap.md#getanimationbyname)
+- [getAnimationRange](TextureMap.md#getanimationrange)
+- [getAnimationRanges](TextureMap.md#getanimationranges)
+- [getBehaviorByName](TextureMap.md#getbehaviorbyname)
+- [getChildMeshes](TextureMap.md#getchildmeshes)
+- [getChildTransformNodes](TextureMap.md#getchildtransformnodes)
+- [getChildren](TextureMap.md#getchildren)
+- [getClassName](TextureMap.md#getclassname)
+- [getDescendants](TextureMap.md#getdescendants)
+- [getDirection](TextureMap.md#getdirection)
+- [getDirectionToRef](TextureMap.md#getdirectiontoref)
+- [getDistanceToCamera](TextureMap.md#getdistancetocamera)
+- [getEngine](TextureMap.md#getengine)
+- [getHierarchyBoundingVectors](TextureMap.md#gethierarchyboundingvectors)
+- [getPhysicsBody](TextureMap.md#getphysicsbody)
+- [getPivotMatrix](TextureMap.md#getpivotmatrix)
+- [getPivotPoint](TextureMap.md#getpivotpoint)
+- [getPivotPointToRef](TextureMap.md#getpivotpointtoref)
+- [getPoseMatrix](TextureMap.md#getposematrix)
+- [getPositionExpressedInLocalSpace](TextureMap.md#getpositionexpressedinlocalspace)
+- [getPositionInCameraSpace](TextureMap.md#getpositionincameraspace)
+- [getScene](TextureMap.md#getscene)
+- [getWorldMatrix](TextureMap.md#getworldmatrix)
+- [instantiateHierarchy](TextureMap.md#instantiatehierarchy)
+- [isDescendantOf](TextureMap.md#isdescendantof)
+- [isDisposed](TextureMap.md#isdisposed)
+- [isEnabled](TextureMap.md#isenabled)
+- [isReady](TextureMap.md#isready)
+- [isSynchronized](TextureMap.md#issynchronized)
+- [isSynchronizedWithParent](TextureMap.md#issynchronizedwithparent)
+- [isUsingPivotMatrix](TextureMap.md#isusingpivotmatrix)
+- [isUsingPostMultiplyPivotMatrix](TextureMap.md#isusingpostmultiplypivotmatrix)
+- [isWorldMatrixCameraDependent](TextureMap.md#isworldmatrixcameradependent)
 - [keyboardControls](TextureMap.md#keyboardcontrols)
+- [locallyTranslate](TextureMap.md#locallytranslate)
+- [lookAt](TextureMap.md#lookat)
+- [markAsDirty](TextureMap.md#markasdirty)
+- [normalizeToUnitCube](TextureMap.md#normalizetounitcube)
+- [registerAfterWorldMatrixUpdate](TextureMap.md#registerafterworldmatrixupdate)
+- [removeBehavior](TextureMap.md#removebehavior)
+- [removeChild](TextureMap.md#removechild)
+- [resetLocalMatrix](TextureMap.md#resetlocalmatrix)
+- [rotate](TextureMap.md#rotate)
+- [rotateAround](TextureMap.md#rotatearound)
+- [serialize](TextureMap.md#serialize)
+- [serializeAnimationRanges](TextureMap.md#serializeanimationranges)
+- [setAbsolutePosition](TextureMap.md#setabsoluteposition)
+- [setDirection](TextureMap.md#setdirection)
+- [setEnabled](TextureMap.md#setenabled)
+- [setParent](TextureMap.md#setparent)
+- [setPivotMatrix](TextureMap.md#setpivotmatrix)
+- [setPivotPoint](TextureMap.md#setpivotpoint)
+- [setPositionWithLocalVector](TextureMap.md#setpositionwithlocalvector)
+- [setPreTransformMatrix](TextureMap.md#setpretransformmatrix)
+- [translate](TextureMap.md#translate)
+- [unfreezeWorldMatrix](TextureMap.md#unfreezeworldmatrix)
+- [unregisterAfterWorldMatrixUpdate](TextureMap.md#unregisterafterworldmatrixupdate)
+- [updateCache](TextureMap.md#updatecache)
+- [updatePoseMatrix](TextureMap.md#updateposematrix)
+- [AddNodeConstructor](TextureMap.md#addnodeconstructor)
+- [Construct](TextureMap.md#construct)
+- [Parse](TextureMap.md#parse)
+- [ParseAnimationRanges](TextureMap.md#parseanimationranges)
 
 ## Constructors
 
@@ -57,11 +233,399 @@
 
 [`TextureMap`](TextureMap.md)
 
+#### Overrides
+
+TransformNode.constructor
+
 #### Defined in
 
-[prefabs/Mapping/textureMap.ts:39](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Mapping/textureMap.ts#L39)
+[src/prefabs/Mapping/textureMap.ts:40](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Mapping/textureMap.ts#L40)
 
 ## Properties
+
+### \_accessibilityTag
+
+• `Protected` **\_accessibilityTag**: `IAccessibilityTag`
+
+#### Inherited from
+
+TransformNode.\_accessibilityTag
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:82
+
+___
+
+### \_cache
+
+• **\_cache**: `any`
+
+#### Inherited from
+
+TransformNode.\_cache
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:119
+
+___
+
+### \_childUpdateId
+
+• **\_childUpdateId**: `number`
+
+#### Inherited from
+
+TransformNode.\_childUpdateId
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:109
+
+___
+
+### \_children
+
+• `Protected` **\_children**: `Node`[]
+
+#### Inherited from
+
+TransformNode.\_children
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:122
+
+___
+
+### \_currentRenderId
+
+• **\_currentRenderId**: `number`
+
+#### Inherited from
+
+TransformNode.\_currentRenderId
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:106
+
+___
+
+### \_disposePhysicsObserver
+
+• **\_disposePhysicsObserver**: `Observer`\<`Node`\>
+
+#### Inherited from
+
+TransformNode.\_disposePhysicsObserver
+
+#### Defined in
+
+node_modules/@babylonjs/core/Physics/v2/physicsEngineComponent.d.ts:35
+
+___
+
+### \_indexInSceneTransformNodesArray
+
+• **\_indexInSceneTransformNodesArray**: `number`
+
+#### Inherited from
+
+TransformNode.\_indexInSceneTransformNodesArray
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:112
+
+___
+
+### \_internalMetadata
+
+• **\_internalMetadata**: `any`
+
+#### Inherited from
+
+TransformNode.\_internalMetadata
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:67
+
+___
+
+### \_isDirty
+
+• `Protected` **\_isDirty**: `boolean`
+
+#### Inherited from
+
+TransformNode.\_isDirty
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:24
+
+___
+
+### \_isNode
+
+• `Readonly` **\_isNode**: ``true``
+
+#### Inherited from
+
+TransformNode.\_isNode
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:160
+
+___
+
+### \_isWorldMatrixFrozen
+
+• `Protected` **\_isWorldMatrixFrozen**: `boolean`
+
+#### Inherited from
+
+TransformNode.\_isWorldMatrixFrozen
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:110
+
+___
+
+### \_localMatrix
+
+• **\_localMatrix**: `Matrix`
+
+#### Inherited from
+
+TransformNode.\_localMatrix
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:101
+
+___
+
+### \_parentContainer
+
+• **\_parentContainer**: `AbstractScene`
+
+#### Inherited from
+
+TransformNode.\_parentContainer
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:93
+
+___
+
+### \_parentNode
+
+• `Protected` **\_parentNode**: `Node`
+
+#### Inherited from
+
+TransformNode.\_parentNode
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:120
+
+___
+
+### \_physicsBody
+
+• **\_physicsBody**: `PhysicsBody`
+
+#### Inherited from
+
+TransformNode.\_physicsBody
+
+#### Defined in
+
+node_modules/@babylonjs/core/Physics/v2/physicsEngineComponent.d.ts:14
+
+___
+
+### \_poseMatrix
+
+• **\_poseMatrix**: `Matrix`
+
+#### Inherited from
+
+TransformNode.\_poseMatrix
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:99
+
+___
+
+### \_postMultiplyPivotMatrix
+
+• **\_postMultiplyPivotMatrix**: `boolean`
+
+#### Inherited from
+
+TransformNode.\_postMultiplyPivotMatrix
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:109
+
+___
+
+### \_ranges
+
+• `Protected` **\_ranges**: `Object`
+
+#### Index signature
+
+▪ [name: `string`]: `Nullable`\<`AnimationRange`\>
+
+#### Inherited from
+
+TransformNode.\_ranges
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:98
+
+___
+
+### \_scaling
+
+• `Protected` **\_scaling**: `Vector3`
+
+#### Inherited from
+
+TransformNode.\_scaling
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:52
+
+___
+
+### \_scene
+
+• **\_scene**: `Scene`
+
+#### Inherited from
+
+TransformNode.\_scene
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:117
+
+___
+
+### \_waitingParentId
+
+• **\_waitingParentId**: `string`
+
+#### Inherited from
+
+TransformNode.\_waitingParentId
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:111
+
+___
+
+### \_waitingParentInstanceIndex
+
+• **\_waitingParentInstanceIndex**: `string`
+
+#### Inherited from
+
+TransformNode.\_waitingParentInstanceIndex
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:113
+
+___
+
+### \_waitingParsedUniqueId
+
+• **\_waitingParsedUniqueId**: `number`
+
+#### Inherited from
+
+TransformNode.\_waitingParsedUniqueId
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:115
+
+___
+
+### \_worldMatrix
+
+• **\_worldMatrix**: `Matrix`
+
+#### Inherited from
+
+TransformNode.\_worldMatrix
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:124
+
+___
+
+### \_worldMatrixDeterminant
+
+• **\_worldMatrixDeterminant**: `number`
+
+#### Inherited from
+
+TransformNode.\_worldMatrixDeterminant
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:126
+
+___
+
+### \_worldMatrixDeterminantIsDirty
+
+• **\_worldMatrixDeterminantIsDirty**: `boolean`
+
+#### Inherited from
+
+TransformNode.\_worldMatrixDeterminantIsDirty
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:128
+
+___
+
+### animations
+
+• **animations**: `Animation`[]
+
+Gets a list of Animations associated with the node
+
+#### Inherited from
+
+TransformNode.animations
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:97
+
+___
 
 ### container
 
@@ -69,7 +633,7 @@
 
 #### Defined in
 
-[prefabs/Mapping/textureMap.ts:30](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Mapping/textureMap.ts#L30)
+[src/prefabs/Mapping/textureMap.ts:31](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Mapping/textureMap.ts#L31)
 
 ___
 
@@ -79,7 +643,60 @@ ___
 
 #### Defined in
 
-[prefabs/Mapping/textureMap.ts:34](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Mapping/textureMap.ts#L34)
+[src/prefabs/Mapping/textureMap.ts:35](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Mapping/textureMap.ts#L35)
+
+___
+
+### id
+
+• **id**: `string`
+
+Gets or sets the id of the node
+
+#### Inherited from
+
+TransformNode.id
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:53
+
+___
+
+### ignoreNonUniformScaling
+
+• **ignoreNonUniformScaling**: `boolean`
+
+Gets or sets a boolean indicating that non uniform scaling (when at least one component is different from others) should be ignored.
+By default the system will update normals to compensate
+
+#### Inherited from
+
+TransformNode.ignoreNonUniformScaling
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:93
+
+___
+
+### inspectableCustomProperties
+
+• **inspectableCustomProperties**: `IInspectable`[]
+
+List of inspectable custom properties (used by the Inspector)
+
+**`See`**
+
+https://doc.babylonjs.com/toolsAndResources/inspector#extensibility
+
+#### Inherited from
+
+TransformNode.inspectableCustomProperties
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:76
 
 ___
 
@@ -89,7 +706,7 @@ ___
 
 #### Defined in
 
-[prefabs/Mapping/textureMap.ts:26](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Mapping/textureMap.ts#L26)
+[src/prefabs/Mapping/textureMap.ts:27](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Mapping/textureMap.ts#L27)
 
 ___
 
@@ -99,7 +716,7 @@ ___
 
 #### Defined in
 
-[prefabs/Mapping/textureMap.ts:29](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Mapping/textureMap.ts#L29)
+[src/prefabs/Mapping/textureMap.ts:30](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Mapping/textureMap.ts#L30)
 
 ___
 
@@ -109,7 +726,23 @@ ___
 
 #### Defined in
 
-[prefabs/Mapping/textureMap.ts:33](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Mapping/textureMap.ts#L33)
+[src/prefabs/Mapping/textureMap.ts:34](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Mapping/textureMap.ts#L34)
+
+___
+
+### metadata
+
+• **metadata**: `any`
+
+Gets or sets an object used to store user defined information for the node
+
+#### Inherited from
+
+TransformNode.metadata
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:65
 
 ___
 
@@ -117,9 +750,139 @@ ___
 
 • **name**: `string`
 
+#### Overrides
+
+TransformNode.name
+
 #### Defined in
 
-[prefabs/Mapping/textureMap.ts:24](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Mapping/textureMap.ts#L24)
+[src/prefabs/Mapping/textureMap.ts:25](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Mapping/textureMap.ts#L25)
+
+___
+
+### onAccessibilityTagChangedObservable
+
+• **onAccessibilityTagChangedObservable**: `Observable`\<`IAccessibilityTag`\>
+
+Observable fired when an accessibility tag is changed
+
+#### Inherited from
+
+TransformNode.onAccessibilityTagChangedObservable
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:86
+
+___
+
+### onAfterWorldMatrixUpdateObservable
+
+• **onAfterWorldMatrixUpdateObservable**: `Observable`\<`TransformNode`\>
+
+An event triggered after the world matrix is updated
+
+#### Inherited from
+
+TransformNode.onAfterWorldMatrixUpdateObservable
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:116
+
+___
+
+### onDisposeObservable
+
+• **onDisposeObservable**: `Observable`\<`Node`\>
+
+An event triggered when the mesh is disposed
+
+#### Inherited from
+
+TransformNode.onDisposeObservable
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:164
+
+___
+
+### onReady
+
+• **onReady**: (`node`: `Node`) => `void`
+
+Callback raised when the node is ready to be used
+
+#### Type declaration
+
+▸ (`node`): `void`
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `node` | `Node` |
+
+##### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.onReady
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:104
+
+___
+
+### physicsBody
+
+• **physicsBody**: `PhysicsBody`
+
+**`See`**
+
+#### Inherited from
+
+TransformNode.physicsBody
+
+#### Defined in
+
+node_modules/@babylonjs/core/Physics/v2/physicsEngineComponent.d.ts:18
+
+___
+
+### reIntegrateRotationIntoRotationQuaternion
+
+• **reIntegrateRotationIntoRotationQuaternion**: `boolean`
+
+Gets or sets a boolean indicating that even if rotationQuaternion is defined, you can keep updating rotation property and Babylon.js will just mix both
+
+#### Inherited from
+
+TransformNode.reIntegrateRotationIntoRotationQuaternion
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:97
+
+___
+
+### reservedDataStore
+
+• **reservedDataStore**: `any`
+
+For internal use only. Please do not use.
+
+#### Inherited from
+
+TransformNode.reservedDataStore
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:71
 
 ___
 
@@ -136,7 +899,7 @@ ___
 
 #### Defined in
 
-[prefabs/Mapping/textureMap.ts:31](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Mapping/textureMap.ts#L31)
+[src/prefabs/Mapping/textureMap.ts:32](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Mapping/textureMap.ts#L32)
 
 ___
 
@@ -146,7 +909,7 @@ ___
 
 #### Defined in
 
-[prefabs/Mapping/textureMap.ts:37](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Mapping/textureMap.ts#L37)
+[src/prefabs/Mapping/textureMap.ts:38](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Mapping/textureMap.ts#L38)
 
 ___
 
@@ -156,7 +919,23 @@ ___
 
 #### Defined in
 
-[prefabs/Mapping/textureMap.ts:36](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Mapping/textureMap.ts#L36)
+[src/prefabs/Mapping/textureMap.ts:37](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Mapping/textureMap.ts#L37)
+
+___
+
+### scalingDeterminant
+
+• **scalingDeterminant**: `number`
+
+Multiplication factor on scale x/y/z when computing the world matrix. Eg. for a 1x1x1 cube setting this to 2 will make it a 2x2x2 cube
+
+#### Inherited from
+
+TransformNode.scalingDeterminant
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:82
 
 ___
 
@@ -166,7 +945,7 @@ ___
 
 #### Defined in
 
-[prefabs/Mapping/textureMap.ts:25](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Mapping/textureMap.ts#L25)
+[src/prefabs/Mapping/textureMap.ts:26](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Mapping/textureMap.ts#L26)
 
 ___
 
@@ -176,7 +955,23 @@ ___
 
 #### Defined in
 
-[prefabs/Mapping/textureMap.ts:35](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Mapping/textureMap.ts#L35)
+[src/prefabs/Mapping/textureMap.ts:36](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Mapping/textureMap.ts#L36)
+
+___
+
+### state
+
+• **state**: `string`
+
+Gets or sets a string used to store user defined state for the node
+
+#### Inherited from
+
+TransformNode.state
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:61
 
 ___
 
@@ -186,7 +981,7 @@ ___
 
 #### Defined in
 
-[prefabs/Mapping/textureMap.ts:27](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Mapping/textureMap.ts#L27)
+[src/prefabs/Mapping/textureMap.ts:28](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Mapping/textureMap.ts#L28)
 
 ___
 
@@ -196,7 +991,23 @@ ___
 
 #### Defined in
 
-[prefabs/Mapping/textureMap.ts:32](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Mapping/textureMap.ts#L32)
+[src/prefabs/Mapping/textureMap.ts:33](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Mapping/textureMap.ts#L33)
+
+___
+
+### uniqueId
+
+• **uniqueId**: `number`
+
+Gets or sets the unique id of the node
+
+#### Inherited from
+
+TransformNode.uniqueId
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:57
 
 ___
 
@@ -206,9 +1017,1495 @@ ___
 
 #### Defined in
 
-[prefabs/Mapping/textureMap.ts:28](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Mapping/textureMap.ts#L28)
+[src/prefabs/Mapping/textureMap.ts:29](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Mapping/textureMap.ts#L29)
+
+___
+
+### BILLBOARDMODE\_ALL
+
+▪ `Static` **BILLBOARDMODE\_ALL**: `number`
+
+Object will rotate to face the camera
+
+#### Inherited from
+
+TransformNode.BILLBOARDMODE\_ALL
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:34
+
+___
+
+### BILLBOARDMODE\_NONE
+
+▪ `Static` **BILLBOARDMODE\_NONE**: `number`
+
+Object will not rotate to face the camera
+
+#### Inherited from
+
+TransformNode.BILLBOARDMODE\_NONE
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:18
+
+___
+
+### BILLBOARDMODE\_USE\_POSITION
+
+▪ `Static` **BILLBOARDMODE\_USE\_POSITION**: `number`
+
+Object will rotate to face the camera's position instead of orientation
+
+#### Inherited from
+
+TransformNode.BILLBOARDMODE\_USE\_POSITION
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:38
+
+___
+
+### BILLBOARDMODE\_X
+
+▪ `Static` **BILLBOARDMODE\_X**: `number`
+
+Object will rotate to face the camera but only on the x axis
+
+#### Inherited from
+
+TransformNode.BILLBOARDMODE\_X
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:22
+
+___
+
+### BILLBOARDMODE\_Y
+
+▪ `Static` **BILLBOARDMODE\_Y**: `number`
+
+Object will rotate to face the camera but only on the y axis
+
+#### Inherited from
+
+TransformNode.BILLBOARDMODE\_Y
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:26
+
+___
+
+### BILLBOARDMODE\_Z
+
+▪ `Static` **BILLBOARDMODE\_Z**: `number`
+
+Object will rotate to face the camera but only on the z axis
+
+#### Inherited from
+
+TransformNode.BILLBOARDMODE\_Z
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:30
+
+___
+
+### BillboardUseParentOrientation
+
+▪ `Static` **BillboardUseParentOrientation**: `boolean`
+
+Child transform with Billboard flags should or should not apply parent rotation (default if off)
+
+#### Inherited from
+
+TransformNode.BillboardUseParentOrientation
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:42
+
+___
+
+### \_AnimationRangeFactory
+
+▪ `Static` **\_AnimationRangeFactory**: (`_name`: `string`, `_from`: `number`, `_to`: `number`) => `AnimationRange`
+
+#### Type declaration
+
+▸ (`_name`, `_from`, `_to`): `AnimationRange`
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `_name` | `string` |
+| `_from` | `number` |
+| `_to` | `number` |
+
+##### Returns
+
+`AnimationRange`
+
+#### Inherited from
+
+TransformNode.\_AnimationRangeFactory
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:28
+
+## Accessors
+
+### absolutePosition
+
+• `get` **absolutePosition**(): `Vector3`
+
+Returns the current mesh absolute position.
+Returns a Vector3.
+
+#### Returns
+
+`Vector3`
+
+#### Inherited from
+
+TransformNode.absolutePosition
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:185
+
+___
+
+### absoluteRotationQuaternion
+
+• `get` **absoluteRotationQuaternion**(): `Quaternion`
+
+Returns the current mesh absolute rotation.
+Returns a Quaternion.
+
+#### Returns
+
+`Quaternion`
+
+#### Inherited from
+
+TransformNode.absoluteRotationQuaternion
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:195
+
+___
+
+### absoluteScaling
+
+• `get` **absoluteScaling**(): `Vector3`
+
+Returns the current mesh absolute scaling.
+Returns a Vector3.
+
+#### Returns
+
+`Vector3`
+
+#### Inherited from
+
+TransformNode.absoluteScaling
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:190
+
+___
+
+### accessibilityTag
+
+• `get` **accessibilityTag**(): `IAccessibilityTag`
+
+#### Returns
+
+`IAccessibilityTag`
+
+#### Inherited from
+
+TransformNode.accessibilityTag
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:81
+
+• `set` **accessibilityTag**(`value`): `void`
+
+Gets or sets the accessibility tag to describe the node for accessibility purpose.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `value` | `IAccessibilityTag` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.accessibilityTag
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:80
+
+___
+
+### animationPropertiesOverride
+
+• `get` **animationPropertiesOverride**(): `AnimationPropertiesOverride`
+
+Gets or sets the animation properties override
+
+#### Returns
+
+`AnimationPropertiesOverride`
+
+#### Inherited from
+
+TransformNode.animationPropertiesOverride
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:152
+
+• `set` **animationPropertiesOverride**(`value`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `value` | `AnimationPropertiesOverride` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.animationPropertiesOverride
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:153
+
+___
+
+### behaviors
+
+• `get` **behaviors**(): `Behavior`\<`Node`\>[]
+
+Gets the list of attached behaviors
+
+#### Returns
+
+`Behavior`\<`Node`\>[]
+
+**`See`**
+
+https://doc.babylonjs.com/features/featuresDeepDive/behaviors
+
+#### Inherited from
+
+TransformNode.behaviors
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:215
+
+___
+
+### billboardMode
+
+• `get` **billboardMode**(): `number`
+
+Gets or sets the billboard mode. Default is 0.
+
+| Value | Type | Description |
+| --- | --- | --- |
+| 0 | BILLBOARDMODE_NONE |  |
+| 1 | BILLBOARDMODE_X |  |
+| 2 | BILLBOARDMODE_Y |  |
+| 4 | BILLBOARDMODE_Z |  |
+| 7 | BILLBOARDMODE_ALL |  |
+
+#### Returns
+
+`number`
+
+#### Inherited from
+
+TransformNode.billboardMode
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:69
+
+• `set` **billboardMode**(`value`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `value` | `number` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.billboardMode
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:70
+
+___
+
+### doNotSerialize
+
+• `get` **doNotSerialize**(): `boolean`
+
+Gets or sets a boolean used to define if the node must be serialized
+
+#### Returns
+
+`boolean`
+
+#### Inherited from
+
+TransformNode.doNotSerialize
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:90
+
+• `set` **doNotSerialize**(`value`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `value` | `boolean` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.doNotSerialize
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:91
+
+___
+
+### forward
+
+• `get` **forward**(): `Vector3`
+
+The forward direction of that transform in world space.
+
+#### Returns
+
+`Vector3`
+
+#### Inherited from
+
+TransformNode.forward
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:157
+
+___
+
+### infiniteDistance
+
+• `get` **infiniteDistance**(): `boolean`
+
+Gets or sets the distance of the object to max, often used by skybox
+
+#### Returns
+
+`boolean`
+
+#### Inherited from
+
+TransformNode.infiniteDistance
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:87
+
+• `set` **infiniteDistance**(`value`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `value` | `boolean` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.infiniteDistance
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:88
+
+___
+
+### isWorldMatrixFrozen
+
+• `get` **isWorldMatrixFrozen**(): `boolean`
+
+True if the World matrix has been frozen.
+
+#### Returns
+
+`boolean`
+
+#### Inherited from
+
+TransformNode.isWorldMatrixFrozen
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:241
+
+___
+
+### nonUniformScaling
+
+• `get` **nonUniformScaling**(): `boolean`
+
+True if the scaling property of this object is non uniform eg. (1,2,1)
+
+#### Returns
+
+`boolean`
+
+#### Inherited from
+
+TransformNode.nonUniformScaling
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:372
+
+___
+
+### onClonedObservable
+
+• `get` **onClonedObservable**(): `Observable`\<`Node`\>
+
+An event triggered when the node is cloned
+
+#### Returns
+
+`Observable`\<`Node`\>
+
+#### Inherited from
+
+TransformNode.onClonedObservable
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:177
+
+___
+
+### onDispose
+
+• `set` **onDispose**(`callback`): `void`
+
+Sets a callback that will be raised when the node will be disposed
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `callback` | () => `void` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.onDispose
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:169
+
+___
+
+### onEnabledStateChangedObservable
+
+• `get` **onEnabledStateChangedObservable**(): `Observable`\<`boolean`\>
+
+An event triggered when the enabled state of the node changes
+
+#### Returns
+
+`Observable`\<`boolean`\>
+
+#### Inherited from
+
+TransformNode.onEnabledStateChangedObservable
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:173
+
+___
+
+### parent
+
+• `get` **parent**(): `Node`
+
+#### Returns
+
+`Node`
+
+#### Inherited from
+
+TransformNode.parent
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:139
+
+• `set` **parent**(`parent`): `void`
+
+Gets or sets the parent of the node (without keeping the current position in the scene)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `parent` | `Node` |
+
+#### Returns
+
+`void`
+
+**`See`**
+
+https://doc.babylonjs.com/features/featuresDeepDive/mesh/transforms/parent_pivot/parent
+
+#### Inherited from
+
+TransformNode.parent
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:138
+
+___
+
+### position
+
+• `get` **position**(): `Vector3`
+
+Gets or set the node position (default is (0.0, 0.0, 0.0))
+
+#### Returns
+
+`Vector3`
+
+#### Inherited from
+
+TransformNode.position
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:126
+
+• `set` **position**(`newPosition`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `newPosition` | `Vector3` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.position
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:127
+
+___
+
+### preserveParentRotationForBillboard
+
+• `get` **preserveParentRotationForBillboard**(): `boolean`
+
+Gets or sets a boolean indicating that parent rotation should be preserved when using billboards.
+This could be useful for glTF objects where parent rotation helps converting from right handed to left handed
+
+#### Returns
+
+`boolean`
+
+#### Inherited from
+
+TransformNode.preserveParentRotationForBillboard
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:76
+
+• `set` **preserveParentRotationForBillboard**(`value`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `value` | `boolean` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.preserveParentRotationForBillboard
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:77
+
+___
+
+### right
+
+• `get` **right**(): `Vector3`
+
+The right direction of that transform in world space.
+
+#### Returns
+
+`Vector3`
+
+#### Inherited from
+
+TransformNode.right
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:165
+
+___
+
+### rotation
+
+• `get` **rotation**(): `Vector3`
+
+Gets or sets the rotation property : a Vector3 defining the rotation value in radians around each local axis X, Y, Z  (default is (0.0, 0.0, 0.0)).
+If rotation quaternion is set, this Vector3 will be ignored and copy from the quaternion
+
+#### Returns
+
+`Vector3`
+
+#### Inherited from
+
+TransformNode.rotation
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:141
+
+• `set` **rotation**(`newRotation`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `newRotation` | `Vector3` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.rotation
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:142
+
+___
+
+### rotationQuaternion
+
+• `get` **rotationQuaternion**(): `Quaternion`
+
+Gets or sets the rotation Quaternion property : this a Quaternion object defining the node rotation by using a unit quaternion (undefined by default, but can be null).
+If set, only the rotationQuaternion is then used to compute the node rotation (ie. node.rotation will be ignored)
+
+#### Returns
+
+`Quaternion`
+
+#### Inherited from
+
+TransformNode.rotationQuaternion
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:152
+
+• `set` **rotationQuaternion**(`quaternion`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `quaternion` | `Quaternion` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.rotationQuaternion
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:153
+
+___
+
+### scaling
+
+• `get` **scaling**(): `Vector3`
+
+Gets or sets the scaling property : a Vector3 defining the node scaling along each local axis X, Y, Z (default is (1.0, 1.0, 1.0)).
+
+#### Returns
+
+`Vector3`
+
+#### Inherited from
+
+TransformNode.scaling
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:146
+
+• `set` **scaling**(`newScaling`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `newScaling` | `Vector3` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.scaling
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:147
+
+___
+
+### up
+
+• `get` **up**(): `Vector3`
+
+The up direction of that transform in world space.
+
+#### Returns
+
+`Vector3`
+
+#### Inherited from
+
+TransformNode.up
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:161
+
+___
+
+### worldMatrixFromCache
+
+• `get` **worldMatrixFromCache**(): `Matrix`
+
+Returns directly the latest state of the mesh World matrix.
+A Matrix is returned.
+
+#### Returns
+
+`Matrix`
+
+#### Inherited from
+
+TransformNode.worldMatrixFromCache
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:234
 
 ## Methods
+
+### \_addToSceneRootNodes
+
+▸ **_addToSceneRootNodes**(): `void`
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.\_addToSceneRootNodes
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:145
+
+___
+
+### \_afterComputeWorldMatrix
+
+▸ **_afterComputeWorldMatrix**(): `void`
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.\_afterComputeWorldMatrix
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:462
+
+___
+
+### \_getActionManagerForTrigger
+
+▸ **_getActionManagerForTrigger**(`trigger?`, `_initialCall?`): `AbstractActionManager`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `trigger?` | `number` |
+| `_initialCall?` | `boolean` |
+
+#### Returns
+
+`AbstractActionManager`
+
+#### Inherited from
+
+TransformNode.\_getActionManagerForTrigger
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:244
+
+___
+
+### \_getDescendants
+
+▸ **_getDescendants**(`results`, `directDescendantsOnly?`, `predicate?`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `results` | `Node`[] |
+| `directDescendantsOnly?` | `boolean` |
+| `predicate?` | (`node`: `Node`) => `boolean` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.\_getDescendants
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:293
+
+___
+
+### \_getEffectiveParent
+
+▸ **_getEffectiveParent**(): `Node`
+
+#### Returns
+
+`Node`
+
+#### Inherited from
+
+TransformNode.\_getEffectiveParent
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:443
+
+___
+
+### \_getWorldMatrixDeterminant
+
+▸ **_getWorldMatrixDeterminant**(): `number`
+
+#### Returns
+
+`number`
+
+#### Inherited from
+
+TransformNode.\_getWorldMatrixDeterminant
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:229
+
+___
+
+### \_initCache
+
+▸ **_initCache**(): `void`
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.\_initCache
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:180
+
+___
+
+### \_isSynchronized
+
+▸ **_isSynchronized**(): `boolean`
+
+#### Returns
+
+`boolean`
+
+#### Inherited from
+
+TransformNode.\_isSynchronized
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:178
+
+___
+
+### \_markSyncedWithParent
+
+▸ **_markSyncedWithParent**(): `void`
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.\_markSyncedWithParent
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:252
+
+___
+
+### \_removeFromSceneRootNodes
+
+▸ **_removeFromSceneRootNodes**(): `void`
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.\_removeFromSceneRootNodes
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:147
+
+___
+
+### \_serializeAsParent
+
+▸ **_serializeAsParent**(`serializationObject`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `serializationObject` | `any` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.\_serializeAsParent
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:143
+
+___
+
+### \_setReady
+
+▸ **_setReady**(`state`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `state` | `boolean` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.\_setReady
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:339
+
+___
+
+### \_syncParentEnabledState
+
+▸ **_syncParentEnabledState**(): `void`
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.\_syncParentEnabledState
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:277
+
+___
+
+### \_updateCache
+
+▸ **_updateCache**(`_ignoreParentClass?`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `_ignoreParentClass?` | `boolean` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.\_updateCache
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:248
+
+___
+
+### \_updateNonUniformScalingState
+
+▸ **_updateNonUniformScalingState**(`value`): `boolean`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `value` | `boolean` |
+
+#### Returns
+
+`boolean`
+
+#### Inherited from
+
+TransformNode.\_updateNonUniformScalingState
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:376
+
+___
+
+### addBehavior
+
+▸ **addBehavior**(`behavior`, `attachImmediately?`): `Node`
+
+Attach a behavior to the node
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `behavior` | `Behavior`\<`Node`\> | defines the behavior to attach |
+| `attachImmediately?` | `boolean` | defines that the behavior must be attached even if the scene is still loading |
+
+#### Returns
+
+`Node`
+
+the current Node
+
+**`See`**
+
+https://doc.babylonjs.com/features/featuresDeepDive/behaviors
+
+#### Inherited from
+
+TransformNode.addBehavior
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:203
+
+___
+
+### addChild
+
+▸ **addChild**(`mesh`, `preserveScalingSign?`): `this`
+
+Adds the passed mesh as a child to the current mesh
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `mesh` | `TransformNode` | defines the child mesh |
+| `preserveScalingSign?` | `boolean` | if true, keep scaling sign of child. Otherwise, scaling sign might change. |
+
+#### Returns
+
+`this`
+
+the current mesh
+
+#### Inherited from
+
+TransformNode.addChild
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:360
+
+___
+
+### addRotation
+
+▸ **addRotation**(`x`, `y`, `z`): `TransformNode`
+
+Adds a rotation step to the mesh current rotation.
+x, y, z are Euler angles expressed in radians.
+This methods updates the current mesh rotation, either mesh.rotation, either mesh.rotationQuaternion if it's set.
+This means this rotation is made in the mesh local space only.
+It's useful to set a custom rotation order different from the BJS standard one YXZ.
+Example : this rotates the mesh first around its local X axis, then around its local Z axis, finally around its local Y axis.
+```javascript
+mesh.addRotation(x1, 0, 0).addRotation(0, 0, z2).addRotation(0, 0, y3);
+```
+Note that `addRotation()` accumulates the passed rotation values to the current ones and computes the .rotation or .rotationQuaternion updated values.
+Under the hood, only quaternions are used. So it's a little faster is you use .rotationQuaternion because it doesn't need to translate them back to Euler angles.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `x` | `number` | Rotation to add |
+| `y` | `number` | Rotation to add |
+| `z` | `number` | Rotation to add |
+
+#### Returns
+
+`TransformNode`
+
+the TransformNode.
+
+#### Inherited from
+
+TransformNode.addRotation
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:439
+
+___
+
+### applyAngularImpulse
+
+▸ **applyAngularImpulse**(`angularImpulse`): `TransformNode`
+
+Apply a physic angular impulse to the mesh
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `angularImpulse` | `Vector3` | defines the torque to apply |
+
+#### Returns
+
+`TransformNode`
+
+the current mesh
+
+#### Inherited from
+
+TransformNode.applyAngularImpulse
+
+#### Defined in
+
+node_modules/@babylonjs/core/Physics/v2/physicsEngineComponent.d.ts:33
+
+___
+
+### applyImpulse
+
+▸ **applyImpulse**(`force`, `contactPoint`): `TransformNode`
+
+Apply a physic impulse to the mesh
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `force` | `Vector3` | defines the force to apply |
+| `contactPoint` | `Vector3` | defines where to apply the force |
+
+#### Returns
+
+`TransformNode`
+
+the current mesh
+
+#### Inherited from
+
+TransformNode.applyImpulse
+
+#### Defined in
+
+node_modules/@babylonjs/core/Physics/v2/physicsEngineComponent.d.ts:28
+
+___
+
+### attachToBone
+
+▸ **attachToBone**(`bone`, `affectedTransformNode`): `TransformNode`
+
+Attach the current TransformNode to another TransformNode associated with a bone
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `bone` | `Bone` | Bone affecting the TransformNode |
+| `affectedTransformNode` | `TransformNode` | TransformNode associated with the bone |
+
+#### Returns
+
+`TransformNode`
+
+this object
+
+#### Inherited from
+
+TransformNode.attachToBone
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:383
+
+___
+
+### beginAnimation
+
+▸ **beginAnimation**(`name`, `loop?`, `speedRatio?`, `onAnimationEnd?`): `Animatable`
+
+Will start the animation sequence
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `name` | `string` | defines the range frames for animation sequence |
+| `loop?` | `boolean` | defines if the animation should loop (false by default) |
+| `speedRatio?` | `number` | defines the speed factor in which to run the animation (1 by default) |
+| `onAnimationEnd?` | () => `void` | defines a function to be executed when the animation ended (undefined by default) |
+
+#### Returns
+
+`Animatable`
+
+the object created for this animation. If range does not exist, it will return null
+
+#### Inherited from
+
+TransformNode.beginAnimation
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:386
+
+___
+
+### clone
+
+▸ **clone**(`name`, `newParent`, `doNotCloneChildren?`): `TransformNode`
+
+Clone the current transform node
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `name` | `string` | Name of the new clone |
+| `newParent` | `Node` | New parent for the clone |
+| `doNotCloneChildren?` | `boolean` | Do not clone children hierarchy |
+
+#### Returns
+
+`TransformNode`
+
+the new transform node
+
+#### Inherited from
+
+TransformNode.clone
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:495
+
+___
+
+### computeWorldMatrix
+
+▸ **computeWorldMatrix**(`force?`, `camera?`): `Matrix`
+
+Computes the world matrix of the node
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `force?` | `boolean` | defines if the cache version should be invalidated forcing the world matrix to be created from scratch |
+| `camera?` | `Camera` | defines the camera used if different from the scene active camera (This is used with modes like Billboard or infinite distance) |
+
+#### Returns
+
+`Matrix`
+
+the world matrix
+
+#### Inherited from
+
+TransformNode.computeWorldMatrix
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:456
+
+___
+
+### createAnimationRange
+
+▸ **createAnimationRange**(`name`, `from`, `to`): `void`
+
+Creates an animation range for this node
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `name` | `string` | defines the name of the range |
+| `from` | `number` | defines the starting key |
+| `to` | `number` | defines the end key |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.createAnimationRange
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:352
+
+___
 
 ### createContainer
 
@@ -220,7 +2517,7 @@ ___
 
 #### Defined in
 
-[prefabs/Mapping/textureMap.ts:64](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Mapping/textureMap.ts#L64)
+[src/prefabs/Mapping/textureMap.ts:64](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Mapping/textureMap.ts#L64)
 
 ___
 
@@ -234,7 +2531,7 @@ ___
 
 #### Defined in
 
-[prefabs/Mapping/textureMap.ts:105](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Mapping/textureMap.ts#L105)
+[src/prefabs/Mapping/textureMap.ts:105](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Mapping/textureMap.ts#L105)
 
 ___
 
@@ -248,7 +2545,7 @@ ___
 
 #### Defined in
 
-[prefabs/Mapping/textureMap.ts:75](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Mapping/textureMap.ts#L75)
+[src/prefabs/Mapping/textureMap.ts:75](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Mapping/textureMap.ts#L75)
 
 ___
 
@@ -262,7 +2559,7 @@ ___
 
 #### Defined in
 
-[prefabs/Mapping/textureMap.ts:123](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Mapping/textureMap.ts#L123)
+[src/prefabs/Mapping/textureMap.ts:123](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Mapping/textureMap.ts#L123)
 
 ___
 
@@ -276,7 +2573,1122 @@ ___
 
 #### Defined in
 
-[prefabs/Mapping/textureMap.ts:85](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Mapping/textureMap.ts#L85)
+[src/prefabs/Mapping/textureMap.ts:85](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Mapping/textureMap.ts#L85)
+
+___
+
+### deleteAnimationRange
+
+▸ **deleteAnimationRange**(`name`, `deleteFrames?`): `void`
+
+Delete a specific animation range
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `name` | `string` | defines the name of the range to delete |
+| `deleteFrames?` | `boolean` | defines if animation frames from the range must be deleted as well |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.deleteAnimationRange
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:358
+
+___
+
+### detachFromBone
+
+▸ **detachFromBone**(`resetToPreviousParent?`): `TransformNode`
+
+Detach the transform node if its associated with a bone
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `resetToPreviousParent?` | `boolean` | Indicates if the parent that was in effect when attachToBone was called should be set back or if we should set parent to null instead (defaults to the latter) |
+
+#### Returns
+
+`TransformNode`
+
+this object
+
+#### Inherited from
+
+TransformNode.detachFromBone
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:389
+
+___
+
+### dispose
+
+▸ **dispose**(`doNotRecurse?`, `disposeMaterialAndTextures?`): `void`
+
+Releases resources associated with this transform node.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `doNotRecurse?` | `boolean` | Set to true to not recurse into each children (recurse into each children by default) |
+| `disposeMaterialAndTextures?` | `boolean` | Set to true to also dispose referenced materials and textures (false by default) |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.dispose
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:522
+
+___
+
+### freezeWorldMatrix
+
+▸ **freezeWorldMatrix**(`newWorldMatrix?`, `decompose?`): `TransformNode`
+
+Prevents the World matrix to be computed any longer
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `newWorldMatrix?` | `Matrix` | defines an optional matrix to use as world matrix |
+| `decompose?` | `boolean` | defines whether to decompose the given newWorldMatrix or directly assign |
+
+#### Returns
+
+`TransformNode`
+
+the TransformNode.
+
+#### Inherited from
+
+TransformNode.freezeWorldMatrix
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:232
+
+___
+
+### getAbsolutePivotPoint
+
+▸ **getAbsolutePivotPoint**(): `Vector3`
+
+Returns a new Vector3 set with the mesh pivot point World coordinates.
+
+#### Returns
+
+`Vector3`
+
+a new Vector3 set with the mesh pivot point World coordinates.
+
+#### Inherited from
+
+TransformNode.getAbsolutePivotPoint
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:328
+
+___
+
+### getAbsolutePivotPointToRef
+
+▸ **getAbsolutePivotPointToRef**(`result`): `TransformNode`
+
+Sets the Vector3 "result" coordinates with the mesh pivot point World coordinates.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `result` | `Vector3` | vector3 to store the result |
+
+#### Returns
+
+`TransformNode`
+
+this TransformNode.
+
+#### Inherited from
+
+TransformNode.getAbsolutePivotPointToRef
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:334
+
+___
+
+### getAbsolutePosition
+
+▸ **getAbsolutePosition**(): `Vector3`
+
+Returns the mesh absolute position in the World.
+
+#### Returns
+
+`Vector3`
+
+a Vector3.
+
+#### Inherited from
+
+TransformNode.getAbsolutePosition
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:246
+
+___
+
+### getAnimationByName
+
+▸ **getAnimationByName**(`name`): `Animation`
+
+Get an animation by name
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `name` | `string` | defines the name of the animation to look for |
+
+#### Returns
+
+`Animation`
+
+null if not found else the requested animation
+
+#### Inherited from
+
+TransformNode.getAnimationByName
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:345
+
+___
+
+### getAnimationRange
+
+▸ **getAnimationRange**(`name`): `AnimationRange`
+
+Get an animation range by name
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `name` | `string` | defines the name of the animation range to look for |
+
+#### Returns
+
+`AnimationRange`
+
+null if not found else the requested animation range
+
+#### Inherited from
+
+TransformNode.getAnimationRange
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:364
+
+___
+
+### getAnimationRanges
+
+▸ **getAnimationRanges**(): `AnimationRange`[]
+
+Gets the list of all animation ranges defined on this node
+
+#### Returns
+
+`AnimationRange`[]
+
+an array
+
+#### Inherited from
+
+TransformNode.getAnimationRanges
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:377
+
+___
+
+### getBehaviorByName
+
+▸ **getBehaviorByName**(`name`): `Behavior`\<`Node`\>
+
+Gets an attached behavior by name
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `name` | `string` | defines the name of the behavior to look for |
+
+#### Returns
+
+`Behavior`\<`Node`\>
+
+null if behavior was not found else the requested behavior
+
+**`See`**
+
+https://doc.babylonjs.com/features/featuresDeepDive/behaviors
+
+#### Inherited from
+
+TransformNode.getBehaviorByName
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:222
+
+___
+
+### getChildMeshes
+
+▸ **getChildMeshes**\<`T`\>(`directDescendantsOnly?`, `predicate?`): `T`[]
+
+Get all child-meshes of this node
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `AbstractMesh` |
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `directDescendantsOnly?` | `boolean` | defines if true only direct descendants of 'this' will be considered, if false direct and also indirect (children of children, an so on in a recursive manner) descendants of 'this' will be considered (Default: false) |
+| `predicate?` | (`node`: `Node`) => node is T | defines an optional predicate that will be called on every evaluated child, the predicate must return true for a given child to be part of the result, otherwise it will be ignored |
+
+#### Returns
+
+`T`[]
+
+an array of AbstractMesh
+
+#### Inherited from
+
+TransformNode.getChildMeshes
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:314
+
+▸ **getChildMeshes**(`directDescendantsOnly?`, `predicate?`): `AbstractMesh`[]
+
+Get all child-meshes of this node
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `directDescendantsOnly?` | `boolean` | defines if true only direct descendants of 'this' will be considered, if false direct and also indirect (children of children, an so on in a recursive manner) descendants of 'this' will be considered (Default: false) |
+| `predicate?` | (`node`: `Node`) => `boolean` | defines an optional predicate that will be called on every evaluated child, the predicate must return true for a given child to be part of the result, otherwise it will be ignored |
+
+#### Returns
+
+`AbstractMesh`[]
+
+an array of AbstractMesh
+
+#### Inherited from
+
+TransformNode.getChildMeshes
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:321
+
+___
+
+### getChildTransformNodes
+
+▸ **getChildTransformNodes**(`directDescendantsOnly?`, `predicate?`): `TransformNode`[]
+
+Get all child-transformNodes of this node
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `directDescendantsOnly?` | `boolean` | defines if true only direct descendants of 'this' will be considered, if false direct and also indirect (children of children, an so on in a recursive manner) descendants of 'this' will be considered |
+| `predicate?` | (`node`: `Node`) => `boolean` | defines an optional predicate that will be called on every evaluated child, the predicate must return true for a given child to be part of the result, otherwise it will be ignored |
+
+#### Returns
+
+`TransformNode`[]
+
+an array of TransformNode
+
+#### Inherited from
+
+TransformNode.getChildTransformNodes
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:516
+
+___
+
+### getChildren
+
+▸ **getChildren**\<`T`\>(`predicate?`, `directDescendantsOnly?`): `T`[]
+
+Get all direct children of this node
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `Node` |
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `predicate?` | (`node`: `Node`) => node is T | defines an optional predicate that will be called on every evaluated child, the predicate must return true for a given child to be part of the result, otherwise it will be ignored |
+| `directDescendantsOnly?` | `boolean` | defines if true only direct descendants of 'this' will be considered, if false direct and also indirect (children of children, an so on in a recursive manner) descendants of 'this' will be considered (Default: true) |
+
+#### Returns
+
+`T`[]
+
+an array of Node
+
+#### Inherited from
+
+TransformNode.getChildren
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:328
+
+▸ **getChildren**(`predicate?`, `directDescendantsOnly?`): `Node`[]
+
+Get all direct children of this node
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `predicate?` | (`node`: `Node`) => `boolean` | defines an optional predicate that will be called on every evaluated child, the predicate must return true for a given child to be part of the result, otherwise it will be ignored |
+| `directDescendantsOnly?` | `boolean` | defines if true only direct descendants of 'this' will be considered, if false direct and also indirect (children of children, an so on in a recursive manner) descendants of 'this' will be considered (Default: true) |
+
+#### Returns
+
+`Node`[]
+
+an array of Node
+
+#### Inherited from
+
+TransformNode.getChildren
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:335
+
+___
+
+### getClassName
+
+▸ **getClassName**(): `string`
+
+Gets a string identifying the name of the class
+
+#### Returns
+
+`string`
+
+"TransformNode" string
+
+#### Inherited from
+
+TransformNode.getClassName
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:122
+
+___
+
+### getDescendants
+
+▸ **getDescendants**\<`T`\>(`directDescendantsOnly?`, `predicate?`): `T`[]
+
+Will return all nodes that have this node as ascendant
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `Node` |
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `directDescendantsOnly?` | `boolean` | defines if true only direct descendants of 'this' will be considered, if false direct and also indirect (children of children, an so on in a recursive manner) descendants of 'this' will be considered |
+| `predicate?` | (`node`: `Node`) => node is T | defines an optional predicate that will be called on every evaluated child, the predicate must return true for a given child to be part of the result, otherwise it will be ignored |
+
+#### Returns
+
+`T`[]
+
+all children nodes of all types
+
+#### Inherited from
+
+TransformNode.getDescendants
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:300
+
+▸ **getDescendants**(`directDescendantsOnly?`, `predicate?`): `Node`[]
+
+Will return all nodes that have this node as ascendant
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `directDescendantsOnly?` | `boolean` | defines if true only direct descendants of 'this' will be considered, if false direct and also indirect (children of children, an so on in a recursive manner) descendants of 'this' will be considered |
+| `predicate?` | (`node`: `Node`) => `boolean` | defines an optional predicate that will be called on every evaluated child, the predicate must return true for a given child to be part of the result, otherwise it will be ignored |
+
+#### Returns
+
+`Node`[]
+
+all children nodes of all types
+
+#### Inherited from
+
+TransformNode.getDescendants
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:307
+
+___
+
+### getDirection
+
+▸ **getDirection**(`localAxis`): `Vector3`
+
+Returns a new Vector3 that is the localAxis, expressed in the mesh local space, rotated like the mesh.
+This Vector3 is expressed in the World space.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `localAxis` | `Vector3` | axis to rotate |
+
+#### Returns
+
+`Vector3`
+
+a new Vector3 that is the localAxis, expressed in the mesh local space, rotated like the mesh.
+
+#### Inherited from
+
+TransformNode.getDirection
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:287
+
+___
+
+### getDirectionToRef
+
+▸ **getDirectionToRef**(`localAxis`, `result`): `TransformNode`
+
+Sets the Vector3 "result" as the rotated Vector3 "localAxis" in the same rotation than the mesh.
+localAxis is expressed in the mesh local space.
+result is computed in the World space from the mesh World matrix.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `localAxis` | `Vector3` | axis to rotate |
+| `result` | `Vector3` | the resulting transformnode |
+
+#### Returns
+
+`TransformNode`
+
+this TransformNode.
+
+#### Inherited from
+
+TransformNode.getDirectionToRef
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:296
+
+___
+
+### getDistanceToCamera
+
+▸ **getDistanceToCamera**(`camera?`): `number`
+
+Returns the distance from the mesh to the active camera
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `camera?` | `Camera` | defines the camera to use |
+
+#### Returns
+
+`number`
+
+the distance
+
+#### Inherited from
+
+TransformNode.getDistanceToCamera
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:487
+
+___
+
+### getEngine
+
+▸ **getEngine**(): `AbstractEngine`
+
+Gets the engine of the node
+
+#### Returns
+
+`AbstractEngine`
+
+a Engine
+
+#### Inherited from
+
+TransformNode.getEngine
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:194
+
+___
+
+### getHierarchyBoundingVectors
+
+▸ **getHierarchyBoundingVectors**(`includeDescendants?`, `predicate?`): `Object`
+
+Return the minimum and maximum world vectors of the entire hierarchy under current node
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `includeDescendants?` | `boolean` | Include bounding info from descendants as well (true by default) |
+| `predicate?` | (`abstractMesh`: `AbstractMesh`) => `boolean` | defines a callback function that can be customize to filter what meshes should be included in the list used to compute the bounding vectors |
+
+#### Returns
+
+`Object`
+
+the new bounding vectors
+
+| Name | Type |
+| :------ | :------ |
+| `max` | `Vector3` |
+| `min` | `Vector3` |
+
+#### Inherited from
+
+TransformNode.getHierarchyBoundingVectors
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:417
+
+___
+
+### getPhysicsBody
+
+▸ **getPhysicsBody**(): `PhysicsBody`
+
+#### Returns
+
+`PhysicsBody`
+
+#### Inherited from
+
+TransformNode.getPhysicsBody
+
+#### Defined in
+
+node_modules/@babylonjs/core/Physics/v2/physicsEngineComponent.d.ts:22
+
+___
+
+### getPivotMatrix
+
+▸ **getPivotMatrix**(): `Matrix`
+
+Returns the mesh pivot matrix.
+Default : Identity.
+
+#### Returns
+
+`Matrix`
+
+the matrix
+
+#### Inherited from
+
+TransformNode.getPivotMatrix
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:214
+
+___
+
+### getPivotPoint
+
+▸ **getPivotPoint**(): `Vector3`
+
+Returns a new Vector3 set with the mesh pivot point coordinates in the local space.
+
+#### Returns
+
+`Vector3`
+
+the pivot point
+
+#### Inherited from
+
+TransformNode.getPivotPoint
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:317
+
+___
+
+### getPivotPointToRef
+
+▸ **getPivotPointToRef**(`result`): `TransformNode`
+
+Sets the passed Vector3 "result" with the coordinates of the mesh pivot point in the local space.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `result` | `Vector3` | the vector3 to store the result |
+
+#### Returns
+
+`TransformNode`
+
+this TransformNode.
+
+#### Inherited from
+
+TransformNode.getPivotPointToRef
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:323
+
+___
+
+### getPoseMatrix
+
+▸ **getPoseMatrix**(): `Matrix`
+
+Returns the mesh Pose matrix.
+
+#### Returns
+
+`Matrix`
+
+the pose matrix
+
+#### Inherited from
+
+TransformNode.getPoseMatrix
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:176
+
+___
+
+### getPositionExpressedInLocalSpace
+
+▸ **getPositionExpressedInLocalSpace**(): `Vector3`
+
+Returns the mesh position in the local space from the current World matrix values.
+
+#### Returns
+
+`Vector3`
+
+a new Vector3.
+
+#### Inherited from
+
+TransformNode.getPositionExpressedInLocalSpace
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:263
+
+___
+
+### getPositionInCameraSpace
+
+▸ **getPositionInCameraSpace**(`camera?`): `Vector3`
+
+Gets the position of the current mesh in camera space
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `camera?` | `Camera` | defines the camera to use |
+
+#### Returns
+
+`Vector3`
+
+a position
+
+#### Inherited from
+
+TransformNode.getPositionInCameraSpace
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:481
+
+___
+
+### getScene
+
+▸ **getScene**(): `Scene`
+
+Gets the scene of the node
+
+#### Returns
+
+`Scene`
+
+a scene
+
+#### Inherited from
+
+TransformNode.getScene
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:189
+
+___
+
+### getWorldMatrix
+
+▸ **getWorldMatrix**(): `Matrix`
+
+Returns the latest update of the World matrix
+
+#### Returns
+
+`Matrix`
+
+a Matrix
+
+#### Inherited from
+
+TransformNode.getWorldMatrix
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:227
+
+___
+
+### instantiateHierarchy
+
+▸ **instantiateHierarchy**(`newParent?`, `options?`, `onNewNodeCreated?`): `TransformNode`
+
+Instantiate (when possible) or clone that node with its hierarchy
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `newParent?` | `TransformNode` | defines the new parent to use for the instance (or clone) |
+| `options?` | `Object` | defines options to configure how copy is done |
+| `options.doNotInstantiate` | `boolean` \| (`node`: `TransformNode`) => `boolean` | defines if the model must be instantiated or just cloned |
+| `onNewNodeCreated?` | (`source`: `TransformNode`, `clone`: `TransformNode`) => `void` | defines an option callback to call when a clone or an instance is created |
+
+#### Returns
+
+`TransformNode`
+
+an instance (or a clone) of the current node with its hierarchy
+
+#### Inherited from
+
+TransformNode.instantiateHierarchy
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:223
+
+___
+
+### isDescendantOf
+
+▸ **isDescendantOf**(`ancestor`): `boolean`
+
+Is this node a descendant of the given node?
+The function will iterate up the hierarchy until the ancestor was found or no more parents defined
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `ancestor` | `Node` | defines the parent node to inspect |
+
+#### Returns
+
+`boolean`
+
+a boolean indicating if this node is a descendant of the given node
+
+#### Inherited from
+
+TransformNode.isDescendantOf
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:289
+
+___
+
+### isDisposed
+
+▸ **isDisposed**(): `boolean`
+
+Gets a boolean indicating if the node has been disposed
+
+#### Returns
+
+`boolean`
+
+true if the node was disposed
+
+#### Inherited from
+
+TransformNode.isDisposed
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:133
+
+___
+
+### isEnabled
+
+▸ **isEnabled**(`checkAncestors?`): `boolean`
+
+Is this node enabled?
+If the node has a parent, all ancestors will be checked and false will be returned if any are false (not enabled), otherwise will return true
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `checkAncestors?` | `boolean` | indicates if this method should check the ancestors. The default is to check the ancestors. If set to false, the method will return the value of this node without checking ancestors |
+
+#### Returns
+
+`boolean`
+
+whether this node (and its parent) is enabled
+
+#### Inherited from
+
+TransformNode.isEnabled
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:275
+
+___
+
+### isReady
+
+▸ **isReady**(`_completeCheck?`): `boolean`
+
+Is this node ready to be used/rendered
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `_completeCheck?` | `boolean` | defines if a complete check (including materials and lights) has to be done (false by default) |
+
+#### Returns
+
+`boolean`
+
+true if the node is ready
+
+#### Inherited from
+
+TransformNode.isReady
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:262
+
+___
+
+### isSynchronized
+
+▸ **isSynchronized**(): `boolean`
+
+#### Returns
+
+`boolean`
+
+#### Inherited from
+
+TransformNode.isSynchronized
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:256
+
+___
+
+### isSynchronizedWithParent
+
+▸ **isSynchronizedWithParent**(): `boolean`
+
+#### Returns
+
+`boolean`
+
+#### Inherited from
+
+TransformNode.isSynchronizedWithParent
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:254
+
+___
+
+### isUsingPivotMatrix
+
+▸ **isUsingPivotMatrix**(): `boolean`
+
+return true if a pivot has been set
+
+#### Returns
+
+`boolean`
+
+true if a pivot matrix is used
+
+#### Inherited from
+
+TransformNode.isUsingPivotMatrix
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:132
+
+___
+
+### isUsingPostMultiplyPivotMatrix
+
+▸ **isUsingPostMultiplyPivotMatrix**(): `boolean`
+
+#### Returns
+
+`boolean`
+
+true if pivot matrix must be cancelled in the world matrix. When this parameter is set to true (default), the inverse of the pivot matrix is also applied at the end to cancel the transformation effect.
+
+#### Inherited from
+
+TransformNode.isUsingPostMultiplyPivotMatrix
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:136
+
+___
+
+### isWorldMatrixCameraDependent
+
+▸ **isWorldMatrixCameraDependent**(): `boolean`
+
+Returns whether the transform node world matrix computation needs the camera information to be computed.
+This is the case when the node is a billboard or has an infinite distance for instance.
+
+#### Returns
+
+`boolean`
+
+true if the world matrix computation needs the camera information to be computed
+
+#### Inherited from
+
+TransformNode.isWorldMatrixCameraDependent
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:449
 
 ___
 
@@ -296,4 +3708,845 @@ ___
 
 #### Defined in
 
-[prefabs/Mapping/textureMap.ts:139](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Mapping/textureMap.ts#L139)
+[src/prefabs/Mapping/textureMap.ts:139](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Mapping/textureMap.ts#L139)
+
+___
+
+### locallyTranslate
+
+▸ **locallyTranslate**(`vector3`): `TransformNode`
+
+Translates the mesh along the passed Vector3 in its local space.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `vector3` | `Vector3` | the distance to translate in localspace |
+
+#### Returns
+
+`TransformNode`
+
+the TransformNode.
+
+#### Inherited from
+
+TransformNode.locallyTranslate
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:269
+
+___
+
+### lookAt
+
+▸ **lookAt**(`targetPoint`, `yawCor?`, `pitchCor?`, `rollCor?`, `space?`): `TransformNode`
+
+Orients a mesh towards a target point. Mesh must be drawn facing user.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `targetPoint` | `Vector3` | the position (must be in same space as current mesh) to look at |
+| `yawCor?` | `number` | optional yaw (y-axis) correction in radians |
+| `pitchCor?` | `number` | optional pitch (x-axis) correction in radians |
+| `rollCor?` | `number` | optional roll (z-axis) correction in radians |
+| `space?` | `Space` | the chosen space of the target |
+
+#### Returns
+
+`TransformNode`
+
+the TransformNode.
+
+#### Inherited from
+
+TransformNode.lookAt
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:280
+
+___
+
+### markAsDirty
+
+▸ **markAsDirty**(`property?`): `Node`
+
+Flag the transform node as dirty (Forcing it to update everything)
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `property?` | `string` | if set to "rotation" the objects rotationQuaternion will be set to null |
+
+#### Returns
+
+`Node`
+
+this  node
+
+#### Inherited from
+
+TransformNode.markAsDirty
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:340
+
+___
+
+### normalizeToUnitCube
+
+▸ **normalizeToUnitCube**(`includeDescendants?`, `ignoreRotation?`, `predicate?`): `TransformNode`
+
+Uniformly scales the mesh to fit inside of a unit cube (1 X 1 X 1 units)
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `includeDescendants?` | `boolean` | Use the hierarchy's bounding box instead of the mesh's bounding box. Default is false |
+| `ignoreRotation?` | `boolean` | ignore rotation when computing the scale (ie. object will be axis aligned). Default is false |
+| `predicate?` | (`node`: `AbstractMesh`) => `boolean` | predicate that is passed in to getHierarchyBoundingVectors when selecting which object should be included when scaling |
+
+#### Returns
+
+`TransformNode`
+
+the current mesh
+
+#### Inherited from
+
+TransformNode.normalizeToUnitCube
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:530
+
+___
+
+### registerAfterWorldMatrixUpdate
+
+▸ **registerAfterWorldMatrixUpdate**(`func`): `TransformNode`
+
+If you'd like to be called back after the mesh position, rotation or scaling has been updated.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `func` | (`mesh`: `TransformNode`) => `void` | callback function to add |
+
+#### Returns
+
+`TransformNode`
+
+the TransformNode.
+
+#### Inherited from
+
+TransformNode.registerAfterWorldMatrixUpdate
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:469
+
+___
+
+### removeBehavior
+
+▸ **removeBehavior**(`behavior`): `Node`
+
+Remove an attached behavior
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `behavior` | `Behavior`\<`Node`\> | defines the behavior to attach |
+
+#### Returns
+
+`Node`
+
+the current Node
+
+**`See`**
+
+https://doc.babylonjs.com/features/featuresDeepDive/behaviors
+
+#### Inherited from
+
+TransformNode.removeBehavior
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:210
+
+___
+
+### removeChild
+
+▸ **removeChild**(`mesh`, `preserveScalingSign?`): `this`
+
+Removes the passed mesh from the current mesh children list
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `mesh` | `TransformNode` | defines the child mesh |
+| `preserveScalingSign?` | `boolean` | if true, keep scaling sign of child. Otherwise, scaling sign might change. |
+
+#### Returns
+
+`this`
+
+the current mesh
+
+#### Inherited from
+
+TransformNode.removeChild
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:367
+
+___
+
+### resetLocalMatrix
+
+▸ **resetLocalMatrix**(`independentOfChildren?`): `void`
+
+Resets this nodeTransform's local matrix to Matrix.Identity().
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `independentOfChildren?` | `boolean` | indicates if all child nodeTransform's world-space transform should be preserved. |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.resetLocalMatrix
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:461
+
+___
+
+### rotate
+
+▸ **rotate**(`axis`, `amount`, `space?`): `TransformNode`
+
+Rotates the mesh around the axis vector for the passed angle (amount) expressed in radians, in the given space.
+space (default LOCAL) can be either Space.LOCAL, either Space.WORLD.
+Note that the property `rotationQuaternion` is then automatically updated and the property `rotation` is set to (0,0,0) and no longer used.
+The passed axis is also normalized.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `axis` | `Vector3` | the axis to rotate around |
+| `amount` | `number` | the amount to rotate in radians |
+| `space?` | `Space` | Space to rotate in (Default: local) |
+
+#### Returns
+
+`TransformNode`
+
+the TransformNode.
+
+#### Inherited from
+
+TransformNode.rotate
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:401
+
+___
+
+### rotateAround
+
+▸ **rotateAround**(`point`, `axis`, `amount`): `TransformNode`
+
+Rotates the mesh around the axis vector for the passed angle (amount) expressed in radians, in world space.
+Note that the property `rotationQuaternion` is then automatically updated and the property `rotation` is set to (0,0,0) and no longer used.
+The passed axis is also normalized. .
+Method is based on http://www.euclideanspace.com/maths/geometry/affine/aroundPoint/index.htm
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `point` | `Vector3` | the point to rotate around |
+| `axis` | `Vector3` | the axis to rotate around |
+| `amount` | `number` | the amount to rotate in radians |
+
+#### Returns
+
+`TransformNode`
+
+the TransformNode
+
+#### Inherited from
+
+TransformNode.rotateAround
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:412
+
+___
+
+### serialize
+
+▸ **serialize**(`currentSerializationObject?`): `any`
+
+Serializes the objects information.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `currentSerializationObject?` | `any` | defines the object to serialize in |
+
+#### Returns
+
+`any`
+
+the serialized object
+
+#### Inherited from
+
+TransformNode.serialize
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:501
+
+___
+
+### serializeAnimationRanges
+
+▸ **serializeAnimationRanges**(): `any`
+
+Serialize animation ranges into a JSON compatible object
+
+#### Returns
+
+`any`
+
+serialization object
+
+#### Inherited from
+
+TransformNode.serializeAnimationRanges
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:391
+
+___
+
+### setAbsolutePosition
+
+▸ **setAbsolutePosition**(`absolutePosition`): `TransformNode`
+
+Sets the mesh absolute position in the World from a Vector3 or an Array(3).
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `absolutePosition` | `Vector3` | the absolute position to set |
+
+#### Returns
+
+`TransformNode`
+
+the TransformNode.
+
+#### Inherited from
+
+TransformNode.setAbsolutePosition
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:252
+
+___
+
+### setDirection
+
+▸ **setDirection**(`localAxis`, `yawCor?`, `pitchCor?`, `rollCor?`): `TransformNode`
+
+Sets this transform node rotation to the given local axis.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `localAxis` | `Vector3` | the axis in local space |
+| `yawCor?` | `number` | optional yaw (y-axis) correction in radians |
+| `pitchCor?` | `number` | optional pitch (x-axis) correction in radians |
+| `rollCor?` | `number` | optional roll (z-axis) correction in radians |
+
+#### Returns
+
+`TransformNode`
+
+this TransformNode
+
+#### Inherited from
+
+TransformNode.setDirection
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:305
+
+___
+
+### setEnabled
+
+▸ **setEnabled**(`value`): `void`
+
+Set the enabled state of this node
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `value` | `boolean` | defines the new enabled state |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.setEnabled
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:282
+
+___
+
+### setParent
+
+▸ **setParent**(`node`, `preserveScalingSign?`, `updatePivot?`): `TransformNode`
+
+Defines the passed node as the parent of the current node.
+The node will remain exactly where it is and its position / rotation will be updated accordingly.
+Note that if the mesh has a pivot matrix / point defined it will be applied after the parent was updated.
+In that case the node will not remain in the same space as it is, as the pivot will be applied.
+To avoid this, you can set updatePivot to true and the pivot will be updated to identity
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `node` | `Node` | the node ot set as the parent |
+| `preserveScalingSign?` | `boolean` | if true, keep scaling sign of child. Otherwise, scaling sign might change. |
+| `updatePivot?` | `boolean` | if true, update the pivot matrix to keep the node in the same space as before |
+
+#### Returns
+
+`TransformNode`
+
+this TransformNode.
+
+**`See`**
+
+https://doc.babylonjs.com/features/featuresDeepDive/mesh/transforms/parent_pivot/parent
+
+#### Inherited from
+
+TransformNode.setParent
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:353
+
+___
+
+### setPivotMatrix
+
+▸ **setPivotMatrix**(`matrix`, `postMultiplyPivotMatrix?`): `TransformNode`
+
+Sets a new pivot matrix to the current node
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `matrix` | `DeepImmutableObject`\<`Matrix`\> | defines the new pivot matrix to use |
+| `postMultiplyPivotMatrix?` | `boolean` | defines if the pivot matrix must be cancelled in the world matrix. When this parameter is set to true (default), the inverse of the pivot matrix is also applied at the end to cancel the transformation effect |
+
+#### Returns
+
+`TransformNode`
+
+the current TransformNode
+
+#### Inherited from
+
+TransformNode.setPivotMatrix
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:208
+
+___
+
+### setPivotPoint
+
+▸ **setPivotPoint**(`point`, `space?`): `TransformNode`
+
+Sets a new pivot point to the current node
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `point` | `Vector3` | defines the new pivot point to use |
+| `space?` | `Space` | defines if the point is in world or local space (local by default) |
+
+#### Returns
+
+`TransformNode`
+
+the current TransformNode
+
+#### Inherited from
+
+TransformNode.setPivotPoint
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:312
+
+___
+
+### setPositionWithLocalVector
+
+▸ **setPositionWithLocalVector**(`vector3`): `TransformNode`
+
+Sets the mesh position in its local space.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `vector3` | `Vector3` | the position to set in localspace |
+
+#### Returns
+
+`TransformNode`
+
+the TransformNode.
+
+#### Inherited from
+
+TransformNode.setPositionWithLocalVector
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:258
+
+___
+
+### setPreTransformMatrix
+
+▸ **setPreTransformMatrix**(`matrix`): `TransformNode`
+
+Sets a new matrix to apply before all other transformation
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `matrix` | `Matrix` | defines the transform matrix |
+
+#### Returns
+
+`TransformNode`
+
+the current TransformNode
+
+#### Inherited from
+
+TransformNode.setPreTransformMatrix
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:201
+
+___
+
+### translate
+
+▸ **translate**(`axis`, `distance`, `space?`): `TransformNode`
+
+Translates the mesh along the axis vector for the passed distance in the given space.
+space (default LOCAL) can be either Space.LOCAL, either Space.WORLD.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `axis` | `Vector3` | the axis to translate in |
+| `distance` | `number` | the distance to translate |
+| `space?` | `Space` | Space to rotate in (Default: local) |
+
+#### Returns
+
+`TransformNode`
+
+the TransformNode.
+
+#### Inherited from
+
+TransformNode.translate
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:421
+
+___
+
+### unfreezeWorldMatrix
+
+▸ **unfreezeWorldMatrix**(): `this`
+
+Allows back the World matrix computation.
+
+#### Returns
+
+`this`
+
+the TransformNode.
+
+#### Inherited from
+
+TransformNode.unfreezeWorldMatrix
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:237
+
+___
+
+### unregisterAfterWorldMatrixUpdate
+
+▸ **unregisterAfterWorldMatrixUpdate**(`func`): `TransformNode`
+
+Removes a registered callback function.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `func` | (`mesh`: `TransformNode`) => `void` | callback function to remove |
+
+#### Returns
+
+`TransformNode`
+
+the TransformNode.
+
+#### Inherited from
+
+TransformNode.unregisterAfterWorldMatrixUpdate
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:475
+
+___
+
+### updateCache
+
+▸ **updateCache**(`force?`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `force?` | `boolean` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.updateCache
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:240
+
+___
+
+### updatePoseMatrix
+
+▸ **updatePoseMatrix**(`matrix`): `TransformNode`
+
+Copies the parameter passed Matrix into the mesh Pose matrix.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `matrix` | `Matrix` | the matrix to copy the pose from |
+
+#### Returns
+
+`TransformNode`
+
+this TransformNode.
+
+#### Inherited from
+
+TransformNode.updatePoseMatrix
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:171
+
+___
+
+### AddNodeConstructor
+
+▸ **AddNodeConstructor**(`type`, `constructorFunc`): `void`
+
+Add a new node constructor
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `type` | `string` | defines the type name of the node to construct |
+| `constructorFunc` | `NodeConstructor` | defines the constructor function |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.AddNodeConstructor
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:35
+
+___
+
+### Construct
+
+▸ **Construct**(`type`, `name`, `scene`, `options?`): () => `Node`
+
+Returns a node constructor based on type name
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `type` | `string` | defines the type name |
+| `name` | `string` | defines the new node name |
+| `scene` | `Scene` | defines the hosting scene |
+| `options?` | `any` | defines optional options to transmit to constructors |
+
+#### Returns
+
+`fn`
+
+the new constructor or null
+
+▸ (): `Node`
+
+##### Returns
+
+`Node`
+
+#### Inherited from
+
+TransformNode.Construct
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:44
+
+___
+
+### Parse
+
+▸ **Parse**(`parsedTransformNode`, `scene`, `rootUrl`): `TransformNode`
+
+Returns a new TransformNode object parsed from the source provided.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `parsedTransformNode` | `any` | is the source. |
+| `scene` | `Scene` | the scene the object belongs to |
+| `rootUrl` | `string` | is a string, it's the root URL to prefix the `delayLoadingFile` property with |
+
+#### Returns
+
+`TransformNode`
+
+a new TransformNode object parsed from the source provided.
+
+#### Inherited from
+
+TransformNode.Parse
+
+#### Defined in
+
+node_modules/@babylonjs/core/Meshes/transformNode.d.ts:509
+
+___
+
+### ParseAnimationRanges
+
+▸ **ParseAnimationRanges**(`node`, `parsedNode`, `_scene`): `void`
+
+Parse animation range data from a serialization object and store them into a given node
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `node` | `Node` | defines where to store the animation ranges |
+| `parsedNode` | `any` | defines the serialization object to read data from |
+| `_scene` | `Scene` | defines the hosting scene |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TransformNode.ParseAnimationRanges
+
+#### Defined in
+
+node_modules/@babylonjs/core/node.d.ts:410

--- a/docs/api/modules.md
+++ b/docs/api/modules.md
@@ -23,6 +23,8 @@
 ### Functions
 
 - [bind](modules.md#bind)
+- [bindInstance](modules.md#bindinstance)
+- [bindThinInstance](modules.md#bindthininstance)
 - [create](modules.md#create)
 - [createAxes](modules.md#createaxes)
 - [createMeshMap](modules.md#createmeshmap)
@@ -47,7 +49,7 @@
 
 #### Defined in
 
-[prefabs/Chromatic/Chromatic.ts:81](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Chromatic/Chromatic.ts#L81)
+[src/prefabs/Chromatic/Chromatic.ts:81](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Chromatic/Chromatic.ts#L81)
 
 ## Functions
 
@@ -82,7 +84,63 @@ or undefined if a selection could not be made.
 
 #### Defined in
 
-[bind.ts:21](https://github.com/jpmorganchase/anu/blob/4a68614/src/bind.ts#L21)
+[src/bind.ts:29](https://github.com/jpmorganchase/anu/blob/9b6add0/src/bind.ts#L29)
+
+___
+
+### bindInstance
+
+▸ **bindInstance**(`mesh`, `data?`, `scene?`): [`Selection`](classes/Selection.md)
+
+Take a selection, a shape type, and data. For each index in the data create a new mesh for each node in the selection as the parent.
+The data index of the mesh is also attached to the mesh node object under the metadata property.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `mesh` | `Mesh` | The mesh to create instances from. |
+| `data` | `object`[] | The data to bind elements too, must be passed as a list of objects where each object represents a row of tabular data. |
+| `scene?` | `Scene` | - |
+
+#### Returns
+
+[`Selection`](classes/Selection.md)
+
+An instance of Selection, a class containing a array of selected nodes, the scene, and the functions of the class Selection,
+or undefined if a selection could not be made.
+
+#### Defined in
+
+[src/bind.ts:47](https://github.com/jpmorganchase/anu/blob/9b6add0/src/bind.ts#L47)
+
+___
+
+### bindThinInstance
+
+▸ **bindThinInstance**(`mesh`, `data?`, `scene?`): [`Selection`](classes/Selection.md)
+
+Take a selection, a shape type, and data. For each index in the data create a new mesh for each node in the selection as the parent.
+The data index of the mesh is also attached to the mesh node object under the metadata property.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `mesh` | `Mesh` | The mesh to create instances from. |
+| `data` | `object`[] | The data to bind elements too, must be passed as a list of objects where each object represents a row of tabular data. |
+| `scene?` | `Scene` | - |
+
+#### Returns
+
+[`Selection`](classes/Selection.md)
+
+An instance of Selection, a class containing a array of selected nodes, the scene, and the functions of the class Selection,
+or undefined if a selection could not be made.
+
+#### Defined in
+
+[src/bind.ts:70](https://github.com/jpmorganchase/anu/blob/9b6add0/src/bind.ts#L70)
 
 ___
 
@@ -116,7 +174,7 @@ A mesh object created with the passed parameters.
 
 #### Defined in
 
-[create.ts:103](https://github.com/jpmorganchase/anu/blob/4a68614/src/create.ts#L103)
+[src/create.ts:103](https://github.com/jpmorganchase/anu/blob/9b6add0/src/create.ts#L103)
 
 ___
 
@@ -138,7 +196,7 @@ ___
 
 #### Defined in
 
-[prefabs/Axis/Axis.ts:127](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Axis/Axis.ts#L127)
+[src/prefabs/Axis/Axis.ts:127](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Axis/Axis.ts#L127)
 
 ___
 
@@ -167,7 +225,7 @@ ___
 
 #### Defined in
 
-[prefabs/Mapping/MeshMap.ts:86](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Mapping/MeshMap.ts#L86)
+[src/prefabs/Mapping/MeshMap.ts:85](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Mapping/MeshMap.ts#L85)
 
 ___
 
@@ -189,7 +247,7 @@ ___
 
 #### Defined in
 
-[prefabs/Text/planeText.ts:65](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Text/planeText.ts#L65)
+[src/prefabs/Text/planeText.ts:70](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Text/planeText.ts#L70)
 
 ___
 
@@ -215,7 +273,7 @@ ___
 
 #### Defined in
 
-[prefabs/Mapping/textureGlobe.ts:123](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Mapping/textureGlobe.ts#L123)
+[src/prefabs/Mapping/textureGlobe.ts:125](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Mapping/textureGlobe.ts#L125)
 
 ___
 
@@ -242,7 +300,7 @@ ___
 
 #### Defined in
 
-[prefabs/Mapping/textureMap.ts:191](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Mapping/textureMap.ts#L191)
+[src/prefabs/Mapping/textureMap.ts:191](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Mapping/textureMap.ts#L191)
 
 ___
 
@@ -264,7 +322,7 @@ ___
 
 #### Defined in
 
-[prefabs/Layout/Layout.ts:258](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Layout/Layout.ts#L258)
+[src/prefabs/Layout/Layout.ts:258](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Layout/Layout.ts#L258)
 
 ___
 
@@ -284,7 +342,7 @@ ___
 
 #### Defined in
 
-[prefabs/Chromatic/Chromatic.ts:68](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Chromatic/Chromatic.ts#L68)
+[src/prefabs/Chromatic/Chromatic.ts:68](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Chromatic/Chromatic.ts#L68)
 
 ___
 
@@ -306,7 +364,7 @@ ___
 
 #### Defined in
 
-[prefabs/Layout/Layout.ts:244](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Layout/Layout.ts#L244)
+[src/prefabs/Layout/Layout.ts:244](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Layout/Layout.ts#L244)
 
 ___
 
@@ -333,7 +391,7 @@ or undefined if a selection could not be made.
 
 #### Defined in
 
-[select.ts:17](https://github.com/jpmorganchase/anu/blob/4a68614/src/select.ts#L17)
+[src/select.ts:18](https://github.com/jpmorganchase/anu/blob/9b6add0/src/select.ts#L18)
 
 ___
 
@@ -361,7 +419,7 @@ or undefined if a selection could not be made.
 
 #### Defined in
 
-[select.ts:98](https://github.com/jpmorganchase/anu/blob/4a68614/src/select.ts#L98)
+[src/select.ts:99](https://github.com/jpmorganchase/anu/blob/9b6add0/src/select.ts#L99)
 
 ___
 
@@ -388,7 +446,7 @@ or undefined if a selection could not be made.
 
 #### Defined in
 
-[select.ts:61](https://github.com/jpmorganchase/anu/blob/4a68614/src/select.ts#L61)
+[src/select.ts:62](https://github.com/jpmorganchase/anu/blob/9b6add0/src/select.ts#L62)
 
 ___
 
@@ -415,7 +473,7 @@ or undefined if a selection could not be made.
 
 #### Defined in
 
-[select.ts:44](https://github.com/jpmorganchase/anu/blob/4a68614/src/select.ts#L44)
+[src/select.ts:45](https://github.com/jpmorganchase/anu/blob/9b6add0/src/select.ts#L45)
 
 ___
 
@@ -442,7 +500,7 @@ or undefined if a selection could not be made.
 
 #### Defined in
 
-[select.ts:78](https://github.com/jpmorganchase/anu/blob/4a68614/src/select.ts#L78)
+[src/select.ts:79](https://github.com/jpmorganchase/anu/blob/9b6add0/src/select.ts#L79)
 
 ___
 
@@ -462,4 +520,4 @@ ___
 
 #### Defined in
 
-[prefabs/Chromatic/Chromatic.ts:72](https://github.com/jpmorganchase/anu/blob/4a68614/src/prefabs/Chromatic/Chromatic.ts#L72)
+[src/prefabs/Chromatic/Chromatic.ts:72](https://github.com/jpmorganchase/anu/blob/9b6add0/src/prefabs/Chromatic/Chromatic.ts#L72)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jpmorganchase/anu",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "description": "",
   "type": "module",
   "files": [

--- a/src/assets/index.d.ts
+++ b/src/assets/index.d.ts
@@ -1,4 +1,4 @@
 declare module '*.png' {
-    const value: any;
-    export = value;
-  }
+  const value: any;
+  export = value;
+}

--- a/src/bind.ts
+++ b/src/bind.ts
@@ -26,7 +26,12 @@ type Property<T, MeshType extends keyof T> = T[MeshType];
  * @returns An instance of Selection, a class containing a array of selected nodes, the scene, and the functions of the class Selection,
  * or undefined if a selection could not be made.
  */
-export function bind<MeshType extends keyof MeshTypes>(shape: MeshType, options?: Property<MeshTypes, MeshType>, data: Array<object> = [{}], scene?: Scene): Selection {
+export function bind<MeshType extends keyof MeshTypes>(
+  shape: MeshType,
+  options?: Property<MeshTypes, MeshType>,
+  data: Array<object> = [{}],
+  scene?: Scene,
+): Selection {
   let meshes: Node[] = [];
   data.forEach((element, i) => {
     var mesh = create(shape, shape, options, element, scene);
@@ -45,7 +50,7 @@ export function bind<MeshType extends keyof MeshTypes>(shape: MeshType, options?
  * or undefined if a selection could not be made.
  */
 export function bindInstance(mesh: Mesh, data: Array<object> = [{}], scene?: Scene): Selection {
-  scene = (scene != undefined) ? scene : mesh.getScene();
+  scene = scene != undefined ? scene : mesh.getScene();
   let meshes: Node[] = [];
   data.forEach((element, i) => {
     var instance = mesh.createInstance(mesh.name + '_' + i);
@@ -54,7 +59,7 @@ export function bindInstance(mesh: Mesh, data: Array<object> = [{}], scene?: Sce
     instance.metadata = { ...mesh.metadata, data: element };
     meshes.push(instance as InstancedMesh);
   });
-  
+
   return new Selection(meshes, scene);
 }
 
@@ -68,11 +73,11 @@ export function bindInstance(mesh: Mesh, data: Array<object> = [{}], scene?: Sce
  * or undefined if a selection could not be made.
  */
 export function bindThinInstance(mesh: Mesh, data: Array<object> = [{}], scene?: Scene): Selection {
-  scene = (scene != undefined) ? scene : mesh.getScene();
+  scene = scene != undefined ? scene : mesh.getScene();
   Tags.EnableFor(mesh);
   mesh.actionManager = new ActionManager(scene);
   mesh.metadata = { ...mesh.metadata, data: data };
- 
+
   let matrices = new Float32Array(16 * data.length * 3);
 
   data.forEach((element, i) => {
@@ -80,8 +85,7 @@ export function bindThinInstance(mesh: Mesh, data: Array<object> = [{}], scene?:
     matrix.copyToArray(matrices, i * 16);
   });
 
-  mesh.thinInstanceSetBuffer("matrix", matrices, 16, false);
+  mesh.thinInstanceSetBuffer('matrix', matrices, 16, false);
 
   return new Selection([mesh], scene);
 }
-

--- a/src/create.ts
+++ b/src/create.ts
@@ -1,7 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright : J.P. Morgan Chase & Co.
 
-import { Mesh, MeshBuilder, TransformNode, Scene, ActionManager, Tags, CreateGreasedLine, GreasedLineMeshBuilderOptions } from '@babylonjs/core';
+import {
+  Mesh,
+  MeshBuilder,
+  TransformNode,
+  Scene,
+  ActionManager,
+  Tags,
+  CreateGreasedLine,
+  GreasedLineMeshBuilderOptions,
+} from '@babylonjs/core';
 import { createPlaneText } from './prefabs/Text/planeText';
 import { createContainer } from './prefabs/Misc/container';
 
@@ -17,10 +26,9 @@ function createCOT(name: string, options: object, scene?: Scene) {
   return new TransformNode(name, scene);
 }
 
-function createGL(name: string, options: GreasedLineMeshBuilderOptions, scene?: Scene){
+function createGL(name: string, options: GreasedLineMeshBuilderOptions, scene?: Scene) {
   return CreateGreasedLine(name, options, {}, scene);
 }
-
 
 const meshList: StringByFunc = {
   cot: createCOT,
@@ -56,36 +64,36 @@ const meshList: StringByFunc = {
 };
 
 export interface MeshTypes {
-  "box": Parameters<typeof MeshBuilder.CreateBox>[1],
-  "cot": any,
-  "sphere": Parameters<typeof MeshBuilder.CreateSphere>[1],
-  "tiledBox": Parameters<typeof MeshBuilder.CreateTiledBox>[1],
-  "cylinder": Parameters<typeof MeshBuilder.CreateCylinder>[1],
-  "capsule":  Parameters<typeof MeshBuilder.CreateCapsule>[1],
-  "plane": Parameters<typeof MeshBuilder.CreatePlane>[1],
-  "tiledPlane": Parameters<typeof MeshBuilder.CreateTiledPlane>[1],
-  "disc": Parameters<typeof MeshBuilder.CreateDisc>[1],
-  "torus": Parameters<typeof MeshBuilder.CreateTorus>[1],
-  "torusKnot": Parameters<typeof MeshBuilder.CreateTorusKnot>[1],
-  "ground": Parameters<typeof MeshBuilder.CreateGround>[1],
-  "tiledGround": Parameters<typeof MeshBuilder.CreateTiledGround>[1],
-  "lines": Parameters<typeof MeshBuilder.CreateLines>[1],
-  "dashedLines": Parameters<typeof MeshBuilder.CreateDashedLines>[1],
-  "lineSystem": Parameters<typeof MeshBuilder.CreateLineSystem>[1],
-  "ribbon": Parameters<typeof MeshBuilder.CreateRibbon>[1],
-  "tube": Parameters<typeof MeshBuilder.CreateTube>[1],
-  "extrude": Parameters<typeof MeshBuilder.ExtrudeShape>[1],
-  "extrudeCustom": Parameters<typeof MeshBuilder.ExtrudeShapeCustom>[1],
-  "lathe": Parameters<typeof MeshBuilder.CreateLathe>[1],
-  "polygon": Parameters<typeof MeshBuilder.CreatePolygon>[1],
-  "extrudePolygon": Parameters<typeof MeshBuilder.ExtrudePolygon>[1],
-  "polyhedra": Parameters<typeof MeshBuilder.CreatePolyhedron>[1],
-  "icosphere": Parameters<typeof MeshBuilder.CreateIcoSphere>[1],
-  "geodesic": Parameters<typeof MeshBuilder.CreateGeodesic>[1],
-  "goldberg": Parameters<typeof MeshBuilder.CreateGoldberg>[1],
-  'planeText': Parameters<typeof createPlaneText>[1],
-  "greasedLine": Parameters<typeof createGL>[1],
-  "container": Parameters<typeof createContainer>[1],
+  box: Parameters<typeof MeshBuilder.CreateBox>[1];
+  cot: any;
+  sphere: Parameters<typeof MeshBuilder.CreateSphere>[1];
+  tiledBox: Parameters<typeof MeshBuilder.CreateTiledBox>[1];
+  cylinder: Parameters<typeof MeshBuilder.CreateCylinder>[1];
+  capsule: Parameters<typeof MeshBuilder.CreateCapsule>[1];
+  plane: Parameters<typeof MeshBuilder.CreatePlane>[1];
+  tiledPlane: Parameters<typeof MeshBuilder.CreateTiledPlane>[1];
+  disc: Parameters<typeof MeshBuilder.CreateDisc>[1];
+  torus: Parameters<typeof MeshBuilder.CreateTorus>[1];
+  torusKnot: Parameters<typeof MeshBuilder.CreateTorusKnot>[1];
+  ground: Parameters<typeof MeshBuilder.CreateGround>[1];
+  tiledGround: Parameters<typeof MeshBuilder.CreateTiledGround>[1];
+  lines: Parameters<typeof MeshBuilder.CreateLines>[1];
+  dashedLines: Parameters<typeof MeshBuilder.CreateDashedLines>[1];
+  lineSystem: Parameters<typeof MeshBuilder.CreateLineSystem>[1];
+  ribbon: Parameters<typeof MeshBuilder.CreateRibbon>[1];
+  tube: Parameters<typeof MeshBuilder.CreateTube>[1];
+  extrude: Parameters<typeof MeshBuilder.ExtrudeShape>[1];
+  extrudeCustom: Parameters<typeof MeshBuilder.ExtrudeShapeCustom>[1];
+  lathe: Parameters<typeof MeshBuilder.CreateLathe>[1];
+  polygon: Parameters<typeof MeshBuilder.CreatePolygon>[1];
+  extrudePolygon: Parameters<typeof MeshBuilder.ExtrudePolygon>[1];
+  polyhedra: Parameters<typeof MeshBuilder.CreatePolyhedron>[1];
+  icosphere: Parameters<typeof MeshBuilder.CreateIcoSphere>[1];
+  geodesic: Parameters<typeof MeshBuilder.CreateGeodesic>[1];
+  goldberg: Parameters<typeof MeshBuilder.CreateGoldberg>[1];
+  planeText: Parameters<typeof createPlaneText>[1];
+  greasedLine: Parameters<typeof createGL>[1];
+  container: Parameters<typeof createContainer>[1];
 }
 
 type Property<T, MeshType extends keyof T> = T[MeshType];
@@ -105,7 +113,7 @@ export function create<MeshType extends keyof MeshTypes>(
   name: string,
   options: Property<MeshTypes, MeshType> = {},
   data: object = {},
-  scene?: Scene
+  scene?: Scene,
 ): Mesh {
   let executedOptions: StringByAny = {};
 

--- a/src/desc.d.ts
+++ b/src/desc.d.ts
@@ -1,2 +1,2 @@
-declare module "babylon-msdf-text";
+declare module 'babylon-msdf-text';
 declare module 'd3-geo-projection';

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ export { Layout } from './prefabs/Layout/Layout';
 
 export { select, selectName, selectId, selectTag, selectData } from './select';
 export { create } from './create';
-export { bind, bindInstance, bindThinInstance} from './bind';
+export { bind, bindInstance, bindThinInstance } from './bind';
 export { createPlaneText } from './prefabs/Text/planeText';
 export { createTextureMap } from './prefabs/Mapping/textureMap';
 export { createTextureGlobe } from './prefabs/Mapping/textureGlobe';
@@ -20,6 +20,3 @@ export { planeLayout, cylinderLayout } from './prefabs/Layout/Layout';
 export { createAxes } from './prefabs/Axis/Axis';
 export { ordinalChromatic, sequentialChromatic, schemes } from './prefabs/Chromatic/Chromatic';
 export { createMeshMap } from './prefabs/Mapping/MeshMap';
-
-
-

--- a/src/prefabs/Axis/Axis.ts
+++ b/src/prefabs/Axis/Axis.ts
@@ -15,7 +15,7 @@ interface AxisOptions {
   xScale?: any;
   yScale?: any;
   zScale?: any;
-  scale?: {x?: any, y?: any, z?: any},
+  scale?: { x?: any; y?: any; z?: any };
   domain?: boolean;
   domainOptions?: any;
   domainMaterialOptions?: any;
@@ -25,34 +25,34 @@ interface AxisOptions {
   grid?: boolean;
   gridOptions?: any;
   gridProperties?: any;
-  gridTicks?: {x?: any, y?: any, z?: any};
+  gridTicks?: { x?: any; y?: any; z?: any };
   label?: boolean;
   labelOptions?: any;
   labelProperties?: any;
-  labelTicks?: {x?: any, y?: any, z?: any};
-  labelFormat?: {x? : any, y?: any, z?: any};
-  atlas?: Texture
+  labelTicks?: { x?: any; y?: any; z?: any };
+  labelFormat?: { x?: any; y?: any; z?: any };
+  atlas?: Texture;
 }
 
-export class Axes extends TransformNode{
+export class Axes extends TransformNode {
   options: AxisOptions;
   CoT: Selection;
   scales: any;
   domain: Selection;
-  background: {x?: Selection, y?: Selection, z?: Selection};;
+  background: { x?: Selection; y?: Selection; z?: Selection };
   grid: Selection;
-  label: {x?: Selection, y?: Selection, z?: Selection};
+  label: { x?: Selection; y?: Selection; z?: Selection };
 
   constructor(name: string, scene: Scene, options: AxisOptions = {}) {
-    super(name, scene, true)
+    super(name, scene, true);
     this.name = name;
     this.options = options;
-    this.parent = (this.options.parent instanceof Selection) ? this.options.parent.selected[0] : this.options.parent;
+    this.parent = this.options.parent instanceof Selection ? this.options.parent.selected[0] : this.options.parent;
     this.CoT = new Selection([this], scene);
     this.scales = this.setScales();
     this.domain = this.options.domain ? this.setDomain() : new Selection([], scene);
     this.background = this.options.background ? this.setBackground() : {};
-    this.grid = this.options.grid ? this.setGrid() : new Selection([], scene); 
+    this.grid = this.options.grid ? this.setGrid() : new Selection([], scene);
     this.label = this.options.label ? this.setLabel() : {};
   }
 
@@ -85,7 +85,6 @@ export class Axes extends TransformNode{
       domainX = scaleX.domain();
       let range = scaleX.range();
       rangeX = [range[0], range.slice(-1)[0]];
-    
     }
 
     if (this.options.scale?.y != undefined) {
@@ -104,9 +103,9 @@ export class Axes extends TransformNode{
     }
 
     let sizes = [rangeX, rangeY, rangeZ].flat().sort();
- 
+
     let size = Math.abs(sizes.slice(-1)[0] - sizes[0]);
-    
+
     return {
       size: size,
       x: { scale: scaleX, range: rangeX, domain: domainX },
@@ -119,13 +118,9 @@ export class Axes extends TransformNode{
   private setBackground = backgroundAlt;
   private setGrid = grid;
   private setLabel = labelAlt;
-
 }
 
-
-
-export function createAxes(name: string, scene: Scene, options: AxisOptions){
-
+export function createAxes(name: string, scene: Scene, options: AxisOptions) {
   const Options: AxisOptions = {
     scale: options.scale,
     parent: options.parent || undefined,
@@ -144,10 +139,10 @@ export function createAxes(name: string, scene: Scene, options: AxisOptions){
     labelProperties: options.labelProperties || {},
     labelTicks: options.labelTicks || {},
     labelFormat: options.labelFormat || {},
-    atlas: options.atlas || new Texture(png, scene)
-  }
+    atlas: options.atlas || new Texture(png, scene),
+  };
 
-  let axes = new Axes(name, scene, Options)
+  let axes = new Axes(name, scene, Options);
 
   return axes;
 }

--- a/src/prefabs/Axis/background.ts
+++ b/src/prefabs/Axis/background.ts
@@ -6,7 +6,6 @@ import { Axes } from './Axis';
 import assign from 'lodash-es/assign';
 import { Selection } from '../../selection';
 
-
 export function backgroundAlt(this: Axes) {
   let scaleX = this.scales.x.scale;
   let rangeX = this.scales.x.range;
@@ -20,7 +19,7 @@ export function backgroundAlt(this: Axes) {
   let rangeZ = this.scales.z.range;
   let domainZ = this.scales.z.domain;
 
-  let selections: {x?: Selection, y?: Selection, z?: Selection} = {};
+  let selections: { x?: Selection; y?: Selection; z?: Selection } = {};
 
   if (this.options.scale?.x != undefined && this.options.scale?.y != undefined) {
     let planePosition: Vector3 | ((d: any) => Vector3) = new Vector3(0, 0, 0);
@@ -68,7 +67,7 @@ export function backgroundAlt(this: Axes) {
       .material(new StandardMaterial(this.name + '_backgroundY_material', this._scene))
       .props(assign({}, default_properties, this.options.backgroundProperties));
 
-      selections.y = backgroundMeshY;
+    selections.y = backgroundMeshY;
   }
 
   if (this.options.scale?.z != undefined && this.options.scale?.x != undefined) {
@@ -93,10 +92,8 @@ export function backgroundAlt(this: Axes) {
       .material(new StandardMaterial(this.name + '_backgroundZ_material', this._scene))
       .props(assign({}, default_properties, this.options.backgroundProperties));
 
-      selections.z = backgroundMeshZ;
+    selections.z = backgroundMeshZ;
   }
-
-
 
   return selections;
 }

--- a/src/prefabs/Axis/domain.ts
+++ b/src/prefabs/Axis/domain.ts
@@ -1,14 +1,18 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright : J.P. Morgan Chase & Co.
 
-import { Vector3, Color3, CreateGreasedLine, GreasedLineMeshBuilderOptions, GreasedLineMaterialBuilderOptions } from '@babylonjs/core';
+import {
+  Vector3,
+  Color3,
+  CreateGreasedLine,
+  GreasedLineMeshBuilderOptions,
+  GreasedLineMaterialBuilderOptions,
+} from '@babylonjs/core';
 import { assign } from 'lodash-es';
 import { Axes } from './Axis';
 import { Selection } from '../../selection';
 
-export function domain(
-  this: Axes
-): Selection {
+export function domain(this: Axes): Selection {
   let scaleX = this.scales.x.scale;
   let rangeX = this.scales.x.range;
   let domainX = this.scales.x.domain;
@@ -33,31 +37,32 @@ export function domain(
     path.push(new Vector3(rangeX[1], rangeY[0], rangeZ[0]), new Vector3(rangeX[1], rangeY[0], rangeZ[1]));
   }
 
-  let default_options: GreasedLineMeshBuilderOptions = { points: path, 
-                          updatable: false 
-                        };
+  let default_options: GreasedLineMeshBuilderOptions = { points: path, updatable: false };
 
-  let default_material: GreasedLineMaterialBuilderOptions= {  createAndAssignMaterial: true,
-                            width: 5,
-                            sizeAttenuation: true,
-                            materialType: 0,
-                            color: Color3.White(),
-                            colorMode: 0,
-                            useColors: false,
-                            useDash: false,
-                            visibility: 1
-                          }  
+  let default_material: GreasedLineMaterialBuilderOptions = {
+    createAndAssignMaterial: true,
+    width: 5,
+    sizeAttenuation: true,
+    materialType: 0,
+    color: Color3.White(),
+    colorMode: 0,
+    useColors: false,
+    useDash: false,
+    visibility: 1,
+  };
 
-  let greasedLine = CreateGreasedLine('greasedLine', 
-                                      assign({}, default_options, this.options.domainOptions),
-                                      assign({}, default_material, this.options.domainMaterialOptions),
-                                      this._scene);
+  let greasedLine = CreateGreasedLine(
+    'greasedLine',
+    assign({}, default_options, this.options.domainOptions),
+    assign({}, default_material, this.options.domainMaterialOptions),
+    this._scene,
+  );
 
   greasedLine.parent = this.CoT.selected[0];
 
-  let domain = new Selection([greasedLine], this._scene)
+  let domain = new Selection([greasedLine], this._scene);
 
-  domain.prop("name", this.name + "_domain")
+  domain.prop('name', this.name + '_domain');
 
   return domain;
 }

--- a/src/prefabs/Axis/grid.ts
+++ b/src/prefabs/Axis/grid.ts
@@ -5,9 +5,7 @@ import { Color3, Vector3 } from '@babylonjs/core';
 import { Axes } from './Axis';
 import assign from 'lodash-es/assign';
 
-export function grid(
-  this: Axes,
-  ) {
+export function grid(this: Axes) {
   let scaleX = this.scales.x.scale;
   let rangeX = this.scales.x.range;
   let domainX = this.scales.x.domain;
@@ -24,8 +22,8 @@ export function grid(
 
   if (this.options.scale?.x != undefined) {
     let ticks; //Not every d3 scale supports the ticks function, for those that don't default to using domain
-    
-    if (this.options.gridTicks?.x != undefined){
+
+    if (this.options.gridTicks?.x != undefined) {
       ticks = this.options.gridTicks.x;
     } else {
       try {
@@ -34,7 +32,7 @@ export function grid(
         ticks = domainX;
       }
     }
-   
+
     let tickPosition: Vector3[] | ((d: any) => Vector3[]) = [new Vector3(0, 0, 0)];
 
     tickPosition = (d) => [
@@ -50,8 +48,8 @@ export function grid(
 
   if (this.options.scale?.y != undefined) {
     let ticks; //Not every d3 scale supports the ticks function, for those that don't default to using domain
-    
-    if (this.options.gridTicks?.y != undefined){
+
+    if (this.options.gridTicks?.y != undefined) {
       ticks = this.options.gridTicks.y;
     } else {
       try {
@@ -76,8 +74,8 @@ export function grid(
 
   if (this.options.scale?.z != undefined) {
     let ticks; //Not every d3 scale supports the ticks function, for those that don't default to using domain
-    
-    if (this.options.gridTicks?.z != undefined){
+
+    if (this.options.gridTicks?.z != undefined) {
       ticks = this.options.gridTicks.z;
     } else {
       try {
@@ -86,7 +84,7 @@ export function grid(
         ticks = domainZ;
       }
     }
-  
+
     let tickPosition: Vector3[] | ((d: any) => Vector3[]) = [new Vector3(0, 0, 0)];
 
     tickPosition = (d) => [
@@ -100,15 +98,13 @@ export function grid(
     }
   }
 
-  let default_options = { lines: linesArray};
-  
-  let default_properties = {  'name': this.name + "_grid",
-                              'alpha': 0.3,
-                              'color': Color3.White()}
+  let default_options = { lines: linesArray };
 
+  let default_properties = { name: this.name + '_grid', alpha: 0.3, color: Color3.White() };
 
-  let tickMesh = this.CoT.bind('lineSystem', assign({}, default_options, this.options.gridOptions))
-    .props(assign({}, default_properties, this.options.gridProperties))
+  let tickMesh = this.CoT.bind('lineSystem', assign({}, default_options, this.options.gridOptions)).props(
+    assign({}, default_properties, this.options.gridProperties),
+  );
 
   return tickMesh;
 }

--- a/src/prefabs/Axis/label.ts
+++ b/src/prefabs/Axis/label.ts
@@ -6,9 +6,7 @@ import { Axes } from './Axis';
 import assign from 'lodash-es/assign';
 import { Selection } from '../../selection';
 
-export function labelAlt(
-  this: Axes
-) {
+export function labelAlt(this: Axes) {
   let scaleX = this.scales.x.scale;
   let rangeX = this.scales.x.range;
   let domainX = this.scales.x.domain;
@@ -21,20 +19,20 @@ export function labelAlt(
   let rangeZ = this.scales.z.range;
   let domainZ = this.scales.z.domain;
 
-  let selections: {x?: Selection, y?: Selection, z?: Selection} = {};
+  let selections: { x?: Selection; y?: Selection; z?: Selection } = {};
 
   //scale label size to 2.5% selection height + width
-  let {min, max} = this.CoT.selected[0].getHierarchyBoundingVectors();
+  let { min, max } = this.CoT.selected[0].getHierarchyBoundingVectors();
   let bounds = new BoundingInfo(min, max).boundingBox;
   let scaleMultiplier = bounds.extendSize.y + bounds.extendSize.x + bounds.extendSize.z;
-  let textHeight = scaleMultiplier * 0.025
+  let textHeight = scaleMultiplier * 0.025;
 
   //console.log(scaleMultiplier,  bounds);
 
   if (this.options.scale?.x != undefined) {
     let ticks; //Not every d3 scale supports the ticks function, for those that don't default to using domain
-    
-    if (this.options.labelTicks?.x != undefined){
+
+    if (this.options.labelTicks?.x != undefined) {
       ticks = this.options.labelTicks.x;
     } else {
       try {
@@ -43,19 +41,22 @@ export function labelAlt(
         ticks = domainX;
       }
     }
-    
 
     let textPosition: Vector3 | ((d: any) => Vector3) = new Vector3(0, 0, 0);
     textPosition = (d) => new Vector3(scaleX(d.text), rangeY[0], rangeZ[0]);
 
     let default_options;
-    if (this.options.labelFormat?.x != undefined){
-      default_options = { text: (d: any) => this.options.labelFormat?.x(d.text), size: textHeight, atlas: this.options.atlas};
+    if (this.options.labelFormat?.x != undefined) {
+      default_options = {
+        text: (d: any) => this.options.labelFormat?.x(d.text),
+        size: textHeight,
+        atlas: this.options.atlas,
+      };
     } else {
-      default_options = { text: (d: any) => d.text, size: textHeight, atlas: this.options.atlas};
+      default_options = { text: (d: any) => d.text, size: textHeight, atlas: this.options.atlas };
     }
 
-    let default_properties = { };
+    let default_properties = {};
 
     let labelMesh = this.CoT.bind(
       'planeText',
@@ -65,7 +66,7 @@ export function labelAlt(
       }),
     )
       .prop('name', this.name + '_labelX')
-      .position((d,n,i) => new Vector3(scaleX(d.text), rangeY[0] - textHeight, rangeZ[0]))
+      .position((d, n, i) => new Vector3(scaleX(d.text), rangeY[0] - textHeight, rangeZ[0]))
       .props(assign({}, default_properties, this.options.labelProperties));
 
     selections.x = labelMesh;
@@ -73,8 +74,8 @@ export function labelAlt(
 
   if (this.options.scale?.y != undefined) {
     let ticks; //Not every d3 scale supports the ticks function, for those that don't default to using domain
-   
-    if (this.options.labelTicks?.y != undefined){
+
+    if (this.options.labelTicks?.y != undefined) {
       ticks = this.options.labelTicks.y;
     } else {
       try {
@@ -83,22 +84,24 @@ export function labelAlt(
         ticks = domainY;
       }
     }
-    
-    
 
     let textPosition: Vector3 | ((d: any) => Vector3) = new Vector3(0, 0, 0);
- 
 
     textPosition = (d) => new Vector3(rangeX[0], scaleY(d.text), rangeZ[0]);
 
     let default_options;
-    if (this.options.labelFormat?.y != undefined){
-      default_options = { text: (d: any) => this.options.labelFormat?.y(d.text), align: "right", size: textHeight,  atlas: this.options.atlas};
+    if (this.options.labelFormat?.y != undefined) {
+      default_options = {
+        text: (d: any) => this.options.labelFormat?.y(d.text),
+        align: 'right',
+        size: textHeight,
+        atlas: this.options.atlas,
+      };
     } else {
-      default_options = { text: (d: any) => d.text, align: "right", size: textHeight,  atlas: this.options.atlas};
+      default_options = { text: (d: any) => d.text, align: 'right', size: textHeight, atlas: this.options.atlas };
     }
 
-    let default_properties = { };
+    let default_properties = {};
 
     let labelMesh = this.CoT.bind(
       'planeText',
@@ -108,17 +111,16 @@ export function labelAlt(
       }),
     )
       .prop('name', this.name + '_labelY')
-      .position((d,n,i) =>  new Vector3(rangeX[0] - 0.05, scaleY(d.text) - textHeight / 2, rangeZ[0]))
+      .position((d, n, i) => new Vector3(rangeX[0] - 0.05, scaleY(d.text) - textHeight / 2, rangeZ[0]))
       .props(assign({}, default_properties, this.options.labelProperties));
 
-      selections.y = labelMesh;
-
+    selections.y = labelMesh;
   }
 
   if (this.options.scale?.z != undefined) {
     let ticks; //Not every d3 scale supports the ticks function, for those that don't default to using domain
-   
-    if (this.options.labelTicks?.z != undefined){
+
+    if (this.options.labelTicks?.z != undefined) {
       ticks = this.options.labelTicks.z;
     } else {
       try {
@@ -127,21 +129,23 @@ export function labelAlt(
         ticks = domainZ;
       }
     }
- 
 
     let textPosition: Vector3 | ((d: any) => Vector3) = new Vector3(0, 0, 0);
 
     textPosition = (d) => new Vector3(rangeX[1], rangeY[0], scaleZ(d.text));
 
-
     let default_options;
-    if (this.options.labelFormat?.z != undefined){
-      default_options = { text: (d: any) => this.options.labelFormat?.z(d.text), size: textHeight,  atlas: this.options.atlas};
+    if (this.options.labelFormat?.z != undefined) {
+      default_options = {
+        text: (d: any) => this.options.labelFormat?.z(d.text),
+        size: textHeight,
+        atlas: this.options.atlas,
+      };
     } else {
-      default_options = { text: (d: any) => d.text, size: textHeight,  atlas: this.options.atlas};
+      default_options = { text: (d: any) => d.text, size: textHeight, atlas: this.options.atlas };
     }
 
-    let default_properties = {'rotation.y': - Math.PI / 2};
+    let default_properties = { 'rotation.y': -Math.PI / 2 };
 
     let labelMesh = this.CoT.bind(
       'planeText',
@@ -151,11 +155,10 @@ export function labelAlt(
       }),
     )
       .prop('name', this.name + '_labelZ')
-      .position((d,n,i) => new Vector3(rangeX[1], rangeY[0] - textHeight, scaleZ(d.text)))
+      .position((d, n, i) => new Vector3(rangeX[1], rangeY[0] - textHeight, scaleZ(d.text)))
       .props(assign({}, default_properties, this.options.labelProperties));
 
-      selections.z = labelMesh;
-
+    selections.z = labelMesh;
   }
 
   return selections;

--- a/src/prefabs/Chromatic/Chromatic.ts
+++ b/src/prefabs/Chromatic/Chromatic.ts
@@ -1,118 +1,131 @@
-import { Color3, Color4, PBRMetallicRoughnessMaterial, PBRSpecularGlossinessMaterial, StandardMaterial, float, int } from "@babylonjs/core";
-import chroma from "chroma-js";
+import {
+  Color3,
+  Color4,
+  PBRMetallicRoughnessMaterial,
+  PBRSpecularGlossinessMaterial,
+  StandardMaterial,
+  float,
+  int,
+} from '@babylonjs/core';
+import chroma from 'chroma-js';
 
-export class OrdinalChromatic{
-    scheme: string[];
+export class OrdinalChromatic {
+  scheme: string[];
 
-    constructor(scheme: string | string[]){
-        this.scheme = (typeof(scheme) === 'string') ? schemes[scheme] : scheme;
-    }
-
-    public toColor3(steps: int = this.scheme.length){
-        return chroma.scale(this.scheme).colors(steps).map((v: string) => Color3.FromHexString(v));
-    }
-
-    public toColor4(steps: int = this.scheme.length){
-        return chroma.scale(this.scheme).colors(steps).map((v: string) => Color4.FromHexString(v));
-    }
-
-    public toStandardMaterial(steps: int = this.scheme.length){
-        return chroma.scale(this.scheme).colors(steps).map((v: string) => makeStandardMaterial(v));
-    }
-
-    public toPBRMaterialRough(steps: int = this.scheme.length){
-        return chroma.scale(this.scheme).colors(steps).map((v: string) => makePBRMaterialRough(v));
-    }
-
-    public toPBRMaterialGlossy(steps: int = this.scheme.length){
-        return chroma.scale(this.scheme).colors(steps).map((v: string) => makePBRMaterialGlossy(v));
-    }
-
-}
-
-export class SequentialChromatic{
-    scheme: string[];
-
-    constructor(scheme: string | string[]){
-        this.scheme = (typeof(scheme) === 'string') ? schemes[scheme] : scheme;
-    }
-
-    public toColor3(steps: int | undefined | number[] = undefined){
-        
-        return (steps === undefined) ? (d: float) => Color3.FromHexString(chroma.scale(this.scheme)(d).hex())
-                                     : (d: float) => Color3.FromHexString(chroma.scale(this.scheme).classes(steps)(d).hex());
-        
-    }
-
-    public toColor4(steps: int | undefined | number[] = undefined){
-        return (steps === undefined) ? (d: float) => Color4.FromHexString(chroma.scale(this.scheme)(d).hex())
-                                     : (d: float) => Color4.FromHexString(chroma.scale(this.scheme).classes(steps)(d).hex());
-    }
-
-    public toStandardMaterial(steps: int | undefined | number[] = undefined){
-        return (steps === undefined) ? (d: float) => makeStandardMaterial(chroma.scale(this.scheme)(d).hex())
-                                     : (d: float) => makeStandardMaterial(chroma.scale(this.scheme).classes(steps)(d).hex());
-    }
-
-    public toPBRMaterialRough(steps: int | undefined | number[] = undefined){
-        return (steps === undefined) ? (d: float) => makePBRMaterialRough(chroma.scale(this.scheme)(d).hex())
-                                     : (d: float) => makePBRMaterialRough(chroma.scale(this.scheme).classes(steps)(d).hex());
-    }
-
-    public toPBRMaterialGlossy(steps: int | undefined | number[] = undefined){
-        return (steps === undefined) ? (d: float) => makePBRMaterialGlossy(chroma.scale(this.scheme)(d).hex())
-                                     : (d: float) => makePBRMaterialGlossy(chroma.scale(this.scheme).classes(steps)(d).hex());
-    }
-}
-
-export function ordinalChromatic(scheme: string | string[]){
-    return new OrdinalChromatic(scheme);
-}
-
-export function sequentialChromatic(scheme: string){
-    return new SequentialChromatic(scheme);
-}
-
-
-interface StringByAny {
-    [key: string]: any;
+  constructor(scheme: string | string[]) {
+    this.scheme = typeof scheme === 'string' ? schemes[scheme] : scheme;
   }
 
-export let schemes: StringByAny = {
-    ...chroma.brewer,
-    'd310': [
-        "#1f77b4",
-        "#ff7f0e",
-        "#2ca02c",
-        "#d62728",
-        "#9467bd",
-        "#8c564b",
-        "#e377c2",
-        "#7f7f7f",
-        "#bcbd22",
-        "#17becf"
-    ]
+  public toColor3(steps: int = this.scheme.length) {
+    return chroma
+      .scale(this.scheme)
+      .colors(steps)
+      .map((v: string) => Color3.FromHexString(v));
+  }
+
+  public toColor4(steps: int = this.scheme.length) {
+    return chroma
+      .scale(this.scheme)
+      .colors(steps)
+      .map((v: string) => Color4.FromHexString(v));
+  }
+
+  public toStandardMaterial(steps: int = this.scheme.length) {
+    return chroma
+      .scale(this.scheme)
+      .colors(steps)
+      .map((v: string) => makeStandardMaterial(v));
+  }
+
+  public toPBRMaterialRough(steps: int = this.scheme.length) {
+    return chroma
+      .scale(this.scheme)
+      .colors(steps)
+      .map((v: string) => makePBRMaterialRough(v));
+  }
+
+  public toPBRMaterialGlossy(steps: int = this.scheme.length) {
+    return chroma
+      .scale(this.scheme)
+      .colors(steps)
+      .map((v: string) => makePBRMaterialGlossy(v));
+  }
 }
+
+export class SequentialChromatic {
+  scheme: string[];
+
+  constructor(scheme: string | string[]) {
+    this.scheme = typeof scheme === 'string' ? schemes[scheme] : scheme;
+  }
+
+  public toColor3(steps: int | undefined | number[] = undefined) {
+    return steps === undefined
+      ? (d: float) => Color3.FromHexString(chroma.scale(this.scheme)(d).hex())
+      : (d: float) => Color3.FromHexString(chroma.scale(this.scheme).classes(steps)(d).hex());
+  }
+
+  public toColor4(steps: int | undefined | number[] = undefined) {
+    return steps === undefined
+      ? (d: float) => Color4.FromHexString(chroma.scale(this.scheme)(d).hex())
+      : (d: float) => Color4.FromHexString(chroma.scale(this.scheme).classes(steps)(d).hex());
+  }
+
+  public toStandardMaterial(steps: int | undefined | number[] = undefined) {
+    return steps === undefined
+      ? (d: float) => makeStandardMaterial(chroma.scale(this.scheme)(d).hex())
+      : (d: float) => makeStandardMaterial(chroma.scale(this.scheme).classes(steps)(d).hex());
+  }
+
+  public toPBRMaterialRough(steps: int | undefined | number[] = undefined) {
+    return steps === undefined
+      ? (d: float) => makePBRMaterialRough(chroma.scale(this.scheme)(d).hex())
+      : (d: float) => makePBRMaterialRough(chroma.scale(this.scheme).classes(steps)(d).hex());
+  }
+
+  public toPBRMaterialGlossy(steps: int | undefined | number[] = undefined) {
+    return steps === undefined
+      ? (d: float) => makePBRMaterialGlossy(chroma.scale(this.scheme)(d).hex())
+      : (d: float) => makePBRMaterialGlossy(chroma.scale(this.scheme).classes(steps)(d).hex());
+  }
+}
+
+export function ordinalChromatic(scheme: string | string[]) {
+  return new OrdinalChromatic(scheme);
+}
+
+export function sequentialChromatic(scheme: string) {
+  return new SequentialChromatic(scheme);
+}
+
+interface StringByAny {
+  [key: string]: any;
+}
+
+export let schemes: StringByAny = {
+  ...chroma.brewer,
+  d310: ['#1f77b4', '#ff7f0e', '#2ca02c', '#d62728', '#9467bd', '#8c564b', '#e377c2', '#7f7f7f', '#bcbd22', '#17becf'],
+};
 
 let linear: StringByAny = {
-    ...chroma.brewer
-}
+  ...chroma.brewer,
+};
 
 function makeStandardMaterial(hex: string) {
-    let material = new StandardMaterial(hex);
-    material.diffuseColor = Color3.FromHexString(hex)
-    return material 
+  let material = new StandardMaterial(hex);
+  material.diffuseColor = Color3.FromHexString(hex);
+  return material;
 }
 
-function makePBRMaterialRough(hex: string){ 
-    let material = new PBRMetallicRoughnessMaterial(hex);
-    material.baseColor = Color3.FromHexString(hex)
-    return material 
+function makePBRMaterialRough(hex: string) {
+  let material = new PBRMetallicRoughnessMaterial(hex);
+  material.baseColor = Color3.FromHexString(hex);
+  return material;
 }
 
-function makePBRMaterialGlossy(hex: string){ 
-    let material = new PBRSpecularGlossinessMaterial(hex);
-    material.diffuseColor = Color3.FromHexString(hex);
-    material.specularColor = Color3.FromHexString(hex);
-    return material 
+function makePBRMaterialGlossy(hex: string) {
+  let material = new PBRSpecularGlossinessMaterial(hex);
+  material.diffuseColor = Color3.FromHexString(hex);
+  material.specularColor = Color3.FromHexString(hex);
+  return material;
 }

--- a/src/prefabs/Interactions/facetPosition.ts
+++ b/src/prefabs/Interactions/facetPosition.ts
@@ -1,21 +1,34 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright : J.P. Morgan Chase & Co.
 
-import { Vector3, Color3, StandardMaterial, ActionManager, ExecuteCodeAction, SixDofDragBehavior, Color4, BoundingInfo, TransformNode, PointerDragBehavior, Tags, Quaternion, Space } from '@babylonjs/core';
+import {
+  Vector3,
+  Color3,
+  StandardMaterial,
+  ActionManager,
+  ExecuteCodeAction,
+  SixDofDragBehavior,
+  Color4,
+  BoundingInfo,
+  TransformNode,
+  PointerDragBehavior,
+  Tags,
+  Quaternion,
+  Space,
+} from '@babylonjs/core';
 import { Selection, create } from '../../index';
 
-
 interface positionUIOptions {
-    name?: string;
-    position?: Vector3;
-    offset?: Vector3;
-    width?: number;
-    radius?: number;
-    material?: any;
-    diffuseColor?: Color3 | Color4;
-    visibility?: number;
-    behavior?: SixDofDragBehavior;
-    billboard?: number;
+  name?: string;
+  position?: Vector3;
+  offset?: Vector3;
+  width?: number;
+  radius?: number;
+  material?: any;
+  diffuseColor?: Color3 | Color4;
+  visibility?: number;
+  behavior?: SixDofDragBehavior;
+  billboard?: number;
 }
 
 /**
@@ -25,37 +38,42 @@ interface positionUIOptions {
  * @returns An instance of Selection, a class containing a array of selected nodes, the scene, and the functions of the class Selection,
  * or undefined if a selection could not be made.
  */
-export function positionUI(this: Selection, options: positionUIOptions = {}): Selection{
-    this.selected.forEach(node => {
-      let { min, max } = node.getHierarchyBoundingVectors(true, (child) => !Tags.MatchesQuery(child, "exclude"));
-      let bounds = new BoundingInfo(min, max);
-      let name = options.name || node.name + "PositionUI"
-      let width = options.width ||  bounds.boundingBox.extendSize.x * 0.5;
-      let radius = options.radius || width * 0.05;
-      let position = options.position || new Vector3(0, -bounds.boundingBox.extendSize.y, -Math.hypot(bounds.boundingBox.extendSize.x, bounds.boundingBox.extendSize.z)); 
-      let offset = options.offset || new Vector3(0, -radius * 2.5 ,0)
-      let billboard = options.billboard || 0;
-      let material: any;
-      if (options.material === undefined){
-          material = new StandardMaterial('PositionUIMat', this.scene);
-          material.diffuseColor = options.diffuseColor || Color3.White()
-      } else {
-          material = options.material;
-      }
-      let visibility = options.visibility || 1
-      let behavior: SixDofDragBehavior;
-      if (options.behavior === undefined){
-        behavior = new SixDofDragBehavior();
-        behavior.faceCameraOnDragStart = true;
-        behavior.rotateAroundYOnly = true;
-        behavior.zDragFactor = 100;
-      } else {
-        behavior = options.behavior;
-      }
-      
+export function positionUI(this: Selection, options: positionUIOptions = {}): Selection {
+  this.selected.forEach((node) => {
+    let { min, max } = node.getHierarchyBoundingVectors(true, (child) => !Tags.MatchesQuery(child, 'exclude'));
+    let bounds = new BoundingInfo(min, max);
+    let name = options.name || node.name + 'PositionUI';
+    let width = options.width || bounds.boundingBox.extendSize.x * 0.5;
+    let radius = options.radius || width * 0.05;
+    let position =
+      options.position ||
+      new Vector3(
+        0,
+        -bounds.boundingBox.extendSize.y,
+        -Math.hypot(bounds.boundingBox.extendSize.x, bounds.boundingBox.extendSize.z),
+      );
+    let offset = options.offset || new Vector3(0, -radius * 2.5, 0);
+    let billboard = options.billboard || 0;
+    let material: any;
+    if (options.material === undefined) {
+      material = new StandardMaterial('PositionUIMat', this.scene);
+      material.diffuseColor = options.diffuseColor || Color3.White();
+    } else {
+      material = options.material;
+    }
+    let visibility = options.visibility || 1;
+    let behavior: SixDofDragBehavior;
+    if (options.behavior === undefined) {
+      behavior = new SixDofDragBehavior();
+      behavior.faceCameraOnDragStart = true;
+      behavior.rotateAroundYOnly = true;
+      behavior.zDragFactor = 100;
+    } else {
+      behavior = options.behavior;
+    }
 
-    let boundingMesh = create('container', name + "Container", {calculateBounds: false}, this.scene);
-    
+    let boundingMesh = create('container', name + 'Container', { calculateBounds: false }, this.scene);
+
     boundingMesh.setParent(node);
     boundingMesh.setBoundingInfo(bounds);
     boundingMesh.isPickable = false;
@@ -63,36 +81,36 @@ export function positionUI(this: Selection, options: positionUIOptions = {}): Se
 
     let boundingSelection = new Selection([boundingMesh], this.scene);
 
-    let grab = boundingSelection.bind("capsule", {height: width, radius: radius})
-                    .name(name)
-                    .position(position.addInPlace(offset))
-                    .rotation(new Vector3(0,0, 1.57))
-                    .material(material)
-                    .prop('visibility', visibility)
-                    .action((d,n,i) => new ExecuteCodeAction( 
-                      ActionManager.OnPickDownTrigger,
-                      () => {
-                         node.addBehavior(behavior);
-                      }
-                    ))
-                    .action((d,n,i) => new ExecuteCodeAction( 
-                      ActionManager.OnPickOutTrigger,
-                      () => {
-                        node.removeBehavior(behavior);
-                      }
-                    ))
-                    .action((d,n,i) => new ExecuteCodeAction( 
-                      ActionManager.OnPickUpTrigger,
-                      () => {
-                        node.removeBehavior(behavior);
-                      }
-                    ))
+    let grab = boundingSelection
+      .bind('capsule', { height: width, radius: radius })
+      .name(name)
+      .position(position.addInPlace(offset))
+      .rotation(new Vector3(0, 0, 1.57))
+      .material(material)
+      .prop('visibility', visibility)
+      .action(
+        (d, n, i) =>
+          new ExecuteCodeAction(ActionManager.OnPickDownTrigger, () => {
+            node.addBehavior(behavior);
+          }),
+      )
+      .action(
+        (d, n, i) =>
+          new ExecuteCodeAction(ActionManager.OnPickOutTrigger, () => {
+            node.removeBehavior(behavior);
+          }),
+      )
+      .action(
+        (d, n, i) =>
+          new ExecuteCodeAction(ActionManager.OnPickUpTrigger, () => {
+            node.removeBehavior(behavior);
+          }),
+      );
 
-                grab.addTags("exclude")
+    grab.addTags('exclude');
+  });
 
-    });
-
-    return this;
+  return this;
 }
 
 interface scaleUIOptions {
@@ -109,35 +127,42 @@ interface scaleUIOptions {
   maximum?: number;
 }
 
-export function scaleUI(this: Selection, options: scaleUIOptions = {}): Selection{
-  this.selected.forEach(node => {
+export function scaleUI(this: Selection, options: scaleUIOptions = {}): Selection {
+  this.selected.forEach((node) => {
     let { min, max } = node.getHierarchyBoundingVectors(true, (child) => !Tags.MatchesQuery(child, 'exclude'));
     let bounds = new BoundingInfo(min, max);
-    let name = options.name || node.name + "ScaleUI"
-    let diameter = options.diameter ||  ((bounds.boundingBox.extendSize.x * 0.5) * 0.05) * 2;
-    let position = options.position || new Vector3(0, -bounds.boundingBox.extendSize.y, -Math.hypot(bounds.boundingBox.extendSize.x, bounds.boundingBox.extendSize.z)); 
-    let offset = options.offset || new Vector3((bounds.boundingBox.extendSize.x * 0.5) * 1.5 / 2, (-diameter / 2) * 2.5, 0)
+    let name = options.name || node.name + 'ScaleUI';
+    let diameter = options.diameter || bounds.boundingBox.extendSize.x * 0.5 * 0.05 * 2;
+    let position =
+      options.position ||
+      new Vector3(
+        0,
+        -bounds.boundingBox.extendSize.y,
+        -Math.hypot(bounds.boundingBox.extendSize.x, bounds.boundingBox.extendSize.z),
+      );
+    let offset =
+      options.offset || new Vector3((bounds.boundingBox.extendSize.x * 0.5 * 1.5) / 2, (-diameter / 2) * 2.5, 0);
     let billboard = options.billboard || 0;
     let material: any;
-    if (options.material === undefined){
-        material = new StandardMaterial('PositionUIMat', this.scene);
-        material.diffuseColor = options.diffuseColor || Color3.White()
+    if (options.material === undefined) {
+      material = new StandardMaterial('PositionUIMat', this.scene);
+      material.diffuseColor = options.diffuseColor || Color3.White();
     } else {
-        material = options.material;
+      material = options.material;
     }
-    let visibility = options.visibility || 1
+    let visibility = options.visibility || 1;
     let behavior: PointerDragBehavior;
-    if (options.behavior === undefined){
-      behavior = new PointerDragBehavior({dragAxis: new Vector3(0,1,0)});
+    if (options.behavior === undefined) {
+      behavior = new PointerDragBehavior({ dragAxis: new Vector3(0, 1, 0) });
       behavior.moveAttached = false;
     } else {
-        behavior = options.behavior;
+      behavior = options.behavior;
     }
     let minimum = options.minimum || -Infinity;
     let maximum = options.maximum || Infinity;
 
-    let boundingMesh = create('container', name + "Container", {calculateBounds: false}, this.scene);
-    
+    let boundingMesh = create('container', name + 'Container', { calculateBounds: false }, this.scene);
+
     boundingMesh.setParent(node);
     boundingMesh.setBoundingInfo(bounds);
     boundingMesh.isPickable = false;
@@ -145,55 +170,53 @@ export function scaleUI(this: Selection, options: scaleUIOptions = {}): Selectio
 
     let boundingSelection = new Selection([boundingMesh], this.scene);
 
-    let scale = boundingSelection.bind("sphere", {diameter: diameter})
-                    .name(name)
-                    .position(position.addInPlace(offset))
-                    .rotation(new Vector3(0,0, 1.57))
-                    .material(material)
-                    .prop('visibility', visibility)
-                    .addTags("exclude")
-                    .action((d,n,i) => new ExecuteCodeAction( 
-                      ActionManager.OnPickDownTrigger,
-                      () => {
-                        n.addBehavior(behavior);
-                      }
-                    ))
-                    .action((d,n,i) => new ExecuteCodeAction( 
-                      ActionManager.OnPickOutTrigger,
-                      () => {
-                        n.removeBehavior(behavior);
-                      }
-                  ))
-                  .action((d,n,i) => new ExecuteCodeAction( 
-                    ActionManager.OnPickUpTrigger,
-                    () => {
-                      n.removeBehavior(behavior);
-                    }
-                  ))
+    let scale = boundingSelection
+      .bind('sphere', { diameter: diameter })
+      .name(name)
+      .position(position.addInPlace(offset))
+      .rotation(new Vector3(0, 0, 1.57))
+      .material(material)
+      .prop('visibility', visibility)
+      .addTags('exclude')
+      .action(
+        (d, n, i) =>
+          new ExecuteCodeAction(ActionManager.OnPickDownTrigger, () => {
+            n.addBehavior(behavior);
+          }),
+      )
+      .action(
+        (d, n, i) =>
+          new ExecuteCodeAction(ActionManager.OnPickOutTrigger, () => {
+            n.removeBehavior(behavior);
+          }),
+      )
+      .action(
+        (d, n, i) =>
+          new ExecuteCodeAction(ActionManager.OnPickUpTrigger, () => {
+            n.removeBehavior(behavior);
+          }),
+      );
 
-            
-    behavior.onDragObservable.add((event)=>{
-        let scaleFactor = -event.dragDistance
-        let currentScale = (node as TransformNode).scaling
-        let afterScale = currentScale.add(new Vector3(scaleFactor, scaleFactor, scaleFactor)) 
-        if (afterScale.x < minimum) {
-          return
-        } else if (afterScale.x > maximum){
-          return
-        } else {
-          (node as TransformNode).scaling = afterScale
-        }
-    })
+    behavior.onDragObservable.add((event) => {
+      let scaleFactor = -event.dragDistance;
+      let currentScale = (node as TransformNode).scaling;
+      let afterScale = currentScale.add(new Vector3(scaleFactor, scaleFactor, scaleFactor));
+      if (afterScale.x < minimum) {
+        return;
+      } else if (afterScale.x > maximum) {
+        return;
+      } else {
+        (node as TransformNode).scaling = afterScale;
+      }
+    });
   });
-            
+
   return this;
 }
 
-
-
 interface rotateUIOptions {
   name?: string;
-  axis?: {[key: string]: Boolean};
+  axis?: { [key: string]: Boolean };
   position?: Vector3;
   offset?: Vector3;
   diameter?: number;
@@ -205,99 +228,112 @@ interface rotateUIOptions {
   //behavior?: {[key: string]: PointerDragBehavior};
 }
 
-export function rotateUI(this: Selection, options: rotateUIOptions = {}): Selection{
-  this.selected.forEach(node => {
+export function rotateUI(this: Selection, options: rotateUIOptions = {}): Selection {
+  this.selected.forEach((node) => {
     let { min, max } = node.getHierarchyBoundingVectors(true, (child) => !Tags.MatchesQuery(child, 'exclude'));
     let bounds = new BoundingInfo(min, max);
-    let name = options.name || node.name + "ScaleUI"
+    let name = options.name || node.name + 'ScaleUI';
     let billboard = options.billboard || 0;
-    let axis = options.axis|| {x: true, y: true, z: true};
-    let diameter = options.diameter ||  ((bounds.boundingBox.extendSize.x * 0.5) * 0.05) * 2;
+    let axis = options.axis || { x: true, y: true, z: true };
+    let diameter = options.diameter || bounds.boundingBox.extendSize.x * 0.5 * 0.05 * 2;
     let thickness = options.thickness || diameter / 2;
-    let position = options.position || new Vector3(0, -bounds.boundingBox.extendSize.y, -Math.hypot(bounds.boundingBox.extendSize.x, bounds.boundingBox.extendSize.z)); 
-    let offset = options.offset || new Vector3(0, (-diameter) * 2.5 , 0)
+    let position =
+      options.position ||
+      new Vector3(
+        0,
+        -bounds.boundingBox.extendSize.y,
+        -Math.hypot(bounds.boundingBox.extendSize.x, bounds.boundingBox.extendSize.z),
+      );
+    let offset = options.offset || new Vector3(0, -diameter * 2.5, 0);
     let material: any;
-    if (options.material === undefined){
-        material = new StandardMaterial('PositionUIMat', this.scene);
-        material.diffuseColor = options.diffuseColor || Color3.White()
+    if (options.material === undefined) {
+      material = new StandardMaterial('PositionUIMat', this.scene);
+      material.diffuseColor = options.diffuseColor || Color3.White();
     } else {
-        material = options.material;
+      material = options.material;
     }
-    let visibility = options.visibility || 1
+    let visibility = options.visibility || 1;
 
-    let behaviors: {[key: string]: PointerDragBehavior};
+    let behaviors: { [key: string]: PointerDragBehavior };
 
     behaviors = {
-      x: new PointerDragBehavior({dragAxis: new Vector3(1,0,0)}),
-      y: new PointerDragBehavior({dragAxis: new Vector3(1,0,0)}),
-      z: new PointerDragBehavior({dragAxis: new Vector3(1,0,0)}),
-    }
+      x: new PointerDragBehavior({ dragAxis: new Vector3(1, 0, 0) }),
+      y: new PointerDragBehavior({ dragAxis: new Vector3(1, 0, 0) }),
+      z: new PointerDragBehavior({ dragAxis: new Vector3(1, 0, 0) }),
+    };
     behaviors.x!.moveAttached = false;
     behaviors.y!.moveAttached = false;
     behaviors.z!.moveAttached = false;
 
+    let data: any = [];
+    Object.keys(axis).forEach((key) => {
+      if (axis[key] == true) data.push({ axis: key });
+    });
 
-    let data: any = []
-    Object.keys(axis).forEach((key) => { if (axis[key] == true)  data.push({"axis": key}) });
+    let boundingMesh = create('container', name + 'Container', { calculateBounds: false }, this.scene);
 
-    let boundingMesh = create('container', name + "Container", {calculateBounds: false}, this.scene);
-    
     boundingMesh.setParent(node);
     boundingMesh.setBoundingInfo(bounds);
     boundingMesh.isPickable = false;
-    boundingMesh.billboardMode = billboard
+    boundingMesh.billboardMode = billboard;
 
     let boundingSelection = new Selection([boundingMesh], this.scene);
 
-    let scale = boundingSelection.bind("torus", {diameter: diameter, thickness: thickness}, data)
-                    .name((d,n,i) => options.name ??= n.name + "_scaleUI")
-                    .position((d) =>
-                    (d.axis == 'x') ? new Vector3(0,0,0).addInPlace(position).addInPlace(offset)  :
-                    (d.axis == 'y') ?  new Vector3(diameter * 1.5,0, 0).addInPlace(position).addInPlace(offset) :
-                    (d.axis == 'z') ?  new Vector3(-diameter * 1.5,0, 0).addInPlace(position).addInPlace(offset) :
-                    new Vector3(0,0,0)
-                  )
-                    .rotation((d) =>
-                      (d.axis == 'x') ? new Vector3(0,0, 1.57) :
-                      (d.axis == 'y') ?  new Vector3(0,0, 0) :
-                      (d.axis == 'z') ?  new Vector3(1.57,0, 0) :
-                      new Vector3(0,0,0)
-                    )
-                    .material(material)
-                    .prop('visibility', visibility)
-                    .addTags("exclude")
-                    .action((d,n,i) => new ExecuteCodeAction( 
-                      ActionManager.OnPickDownTrigger,
-                      () => {
-                        n.addBehavior(behaviors[d.axis]);
-                      }
-                    ))
-                    .action((d,n,i) => new ExecuteCodeAction( 
-                      ActionManager.OnPickOutTrigger,
-                      () => {
-                        n.removeBehavior(behaviors[d.axis]);
-                      }
-                  ))
-                  .action((d,n,i) => new ExecuteCodeAction( 
-                    ActionManager.OnPickUpTrigger,
-                    () => {
-                      n.removeBehavior(behaviors[d.axis]);
-                    }
-                  ))
-              
-                behaviors.x.onDragObservable.add((event)=>{
-                  (node as TransformNode).rotate(new Vector3(1, 0, 0), event.dragDistance, Space.LOCAL);
-                })
+    let scale = boundingSelection
+      .bind('torus', { diameter: diameter, thickness: thickness }, data)
+      .name((d, n, i) => (options.name ??= n.name + '_scaleUI'))
+      .position((d) =>
+        d.axis == 'x'
+          ? new Vector3(0, 0, 0).addInPlace(position).addInPlace(offset)
+          : d.axis == 'y'
+          ? new Vector3(diameter * 1.5, 0, 0).addInPlace(position).addInPlace(offset)
+          : d.axis == 'z'
+          ? new Vector3(-diameter * 1.5, 0, 0).addInPlace(position).addInPlace(offset)
+          : new Vector3(0, 0, 0),
+      )
+      .rotation((d) =>
+        d.axis == 'x'
+          ? new Vector3(0, 0, 1.57)
+          : d.axis == 'y'
+          ? new Vector3(0, 0, 0)
+          : d.axis == 'z'
+          ? new Vector3(1.57, 0, 0)
+          : new Vector3(0, 0, 0),
+      )
+      .material(material)
+      .prop('visibility', visibility)
+      .addTags('exclude')
+      .action(
+        (d, n, i) =>
+          new ExecuteCodeAction(ActionManager.OnPickDownTrigger, () => {
+            n.addBehavior(behaviors[d.axis]);
+          }),
+      )
+      .action(
+        (d, n, i) =>
+          new ExecuteCodeAction(ActionManager.OnPickOutTrigger, () => {
+            n.removeBehavior(behaviors[d.axis]);
+          }),
+      )
+      .action(
+        (d, n, i) =>
+          new ExecuteCodeAction(ActionManager.OnPickUpTrigger, () => {
+            n.removeBehavior(behaviors[d.axis]);
+          }),
+      );
 
-                behaviors.y.onDragObservable.add((event)=>{
-                  (node as TransformNode).rotate(new Vector3(0, -1, 0), event.dragDistance, Space.LOCAL);
-                })
+    behaviors.x.onDragObservable.add((event) => {
+      (node as TransformNode).rotate(new Vector3(1, 0, 0), event.dragDistance, Space.LOCAL);
+    });
 
-                behaviors.z.onDragObservable.add((event)=>{
-                  (node as TransformNode).rotate(new Vector3(0, 0, -1), event.dragDistance, Space.LOCAL);
-                })
-              });
-            
+    behaviors.y.onDragObservable.add((event) => {
+      (node as TransformNode).rotate(new Vector3(0, -1, 0), event.dragDistance, Space.LOCAL);
+    });
+
+    behaviors.z.onDragObservable.add((event) => {
+      (node as TransformNode).rotate(new Vector3(0, 0, -1), event.dragDistance, Space.LOCAL);
+    });
+  });
+
   return this;
 }
-

--- a/src/prefabs/Layout/Layout.ts
+++ b/src/prefabs/Layout/Layout.ts
@@ -1,287 +1,306 @@
 //planeLayout = new anu.planelayout('name', {options}, scene)
 //planeLayout.Update({options})
 //planeLayout.Transform({options})
-import { Selection } from "../../selection";
-import { BoundingInfo, Scene, Vector2, Vector3, Mesh, Animation, BezierCurveEase, TransformNode } from "@babylonjs/core";
+import { Selection } from '../../selection';
+import {
+  BoundingInfo,
+  Scene,
+  Vector2,
+  Vector3,
+  Mesh,
+  Animation,
+  BezierCurveEase,
+  TransformNode,
+} from '@babylonjs/core';
 
 interface LayoutOptions {
-    selection: Selection,
-    rows?: number, 
-    columns?: number,
-    radius?: number,
-    margin?: Vector2,
-    order?: string[],
+  selection: Selection;
+  rows?: number;
+  columns?: number;
+  radius?: number;
+  margin?: Vector2;
+  order?: string[];
+}
+
+export class Layout {
+  name: string;
+  options: LayoutOptions;
+  scene: Scene;
+  currentLayout: Number = 0;
+  root: Mesh;
+
+  constructor(name: string, options: LayoutOptions, scene: Scene) {
+    this.name = name;
+    this.options = options;
+    //scene is required because of animations
+    this.scene = scene;
+    this.root = new Mesh(this.name, this.scene);
   }
 
-export class Layout{
-    name: string;
-    options: LayoutOptions;
-    scene: Scene;
-    currentLayout: Number = 0;
-    root: Mesh;
-    
-    constructor(name: string, options: LayoutOptions, scene: Scene) {
-        this.name = name;
-        this.options = options;
-        //scene is required because of animations
-        this.scene = scene;
-        this.root = new Mesh(this.name, this.scene);
+  public planeLayout() {
+    this.currentLayout = 1;
+    let rownum = this.options.rows || 1;
+    let margin = this.options.margin || new Vector2(0, 0);
+    let chartnum = this.options.selection.selected.length;
+    let boundingBox = this.boundingBoxLocal(this.options.selection);
+    let widthX = boundingBox.boundingBox.maximumWorld.x - boundingBox.boundingBox.minimumWorld.x;
+    let widthY = boundingBox.boundingBox.maximumWorld.y - boundingBox.boundingBox.minimumWorld.y;
+    let colnum = this.options.columns || chartnum;
+
+    colnum = chartnum % rownum == 0 ? chartnum / rownum : Math.floor(chartnum / rownum) + 1;
+
+    this.options.selection.selected.forEach((node, i) => {
+      //(node.parent as Mesh).showBoundingBox = showBox;
+      node.parent = this.root;
+      this.animatePosition(
+        node as TransformNode,
+        new Vector3(
+          ((i % colnum) - (colnum - 1) / 2.0) * (widthX + margin.x),
+          Math.floor(i / colnum) * (widthY + margin.y),
+          0,
+        ),
+      );
+      this.animateRotation(node as TransformNode, new Vector3(0, 0, 0));
+    });
+
+    return this;
+  }
+
+  public cylinderLayout() {
+    this.currentLayout = 2;
+    let rownum = this.options.rows || 1;
+    let margin = this.options.margin || new Vector2(0, 0);
+    let chartnum = this.options.selection.selected.length;
+    let boundingBox = this.boundingBoxLocal(this.options.selection);
+    let radius = this.options.radius || 5;
+    let widthX = boundingBox.boundingBox.maximumWorld.x - boundingBox.boundingBox.minimumWorld.x;
+    let widthY = boundingBox.boundingBox.maximumWorld.y - boundingBox.boundingBox.minimumWorld.y;
+    let colnum = this.options.columns || chartnum;
+
+    colnum = chartnum % rownum == 0 ? chartnum / rownum : Math.floor(chartnum / rownum) + 1;
+
+    let angle = ((Math.atan(widthX / 2 / radius) * 2) / Math.PI) * 180;
+
+    let forward = new Vector3(0, 0, 1);
+    let up = new Vector3(0, 1, 0);
+
+    this.options.selection.selected.forEach((node, i) => {
+      node.parent = this.root;
+      this.animateRotation(node as TransformNode, new Vector3(0, 0, 0));
+      let origin = new Mesh('vect', this.scene);
+      origin.position = new Vector3(0, 0, 0);
+      let rowid = Math.floor(i / colnum);
+      let colid = i % colnum;
+      origin.rotate(new Vector3(0, 1, 0), (colid * (angle + margin.x) * Math.PI) / 180);
+      let originforward = origin.getDirection(forward).normalize();
+      let pos = originforward.multiplyByFloats(radius, radius, radius);
+      let newPos = new Vector3(pos.x, rowid * (widthY + margin.y), pos.z);
+      this.animatePosition(node as TransformNode, newPos);
+      let newRot = origin.rotationQuaternion?.toEulerAngles() || new Vector3(0, 0, 0);
+      this.animateRotation(node as TransformNode, newRot);
+      origin.dispose();
+    });
+
+    return this;
+  }
+
+  public sphereLayout() {
+    this.currentLayout = 3;
+    let rownum = this.options.rows || 1;
+    let margin = this.options.margin || new Vector2(0, 0);
+    let chartnum = this.options.selection.selected.length;
+    let boundingBox = this.boundingBoxLocal(this.options.selection);
+    let radius = this.options.radius || 5;
+    let widthX = boundingBox.boundingBox.maximumWorld.x - boundingBox.boundingBox.minimumWorld.x;
+    let widthY = boundingBox.boundingBox.maximumWorld.y - boundingBox.boundingBox.minimumWorld.y;
+    let colnum = this.options.columns || chartnum;
+
+    colnum = chartnum % rownum == 0 ? chartnum / rownum : Math.floor(chartnum / rownum) + 1;
+
+    let angle = (Math.atan(widthX / 2 / radius) * 2 * 180) / Math.PI;
+    let angleY = (Math.atan(widthY / 2 / radius) * 2 * 180) / Math.PI;
+
+    this.options.selection.selected.forEach((node, i) => {
+      //make a 3D coord using spherical coordinate system
+      node.parent = this.root;
+      let colid = Math.floor(i / colnum) - Math.floor(rownum / 2);
+      let rowid = (i % colnum) - Math.floor(colnum / 2);
+      let anglephi = (Math.min(colid * (angle + margin.y), 360) * Math.PI) / 180;
+      let angletheta = (Math.min(Math.abs(90 - rowid * (angleY + margin.x)), 180) * Math.PI) / 180;
+      let newPos = new Vector3(
+        radius * Math.sin(angletheta) * Math.cos(anglephi),
+        radius * Math.sin(angletheta) * Math.sin(anglephi),
+        radius * Math.cos(angletheta),
+      );
+      this.animatePosition(node as TransformNode, newPos);
+      let newRot = new Vector3(-anglephi, angletheta, 0);
+      this.animateRotation(node as TransformNode, newRot);
+    });
+
+    return this;
+  }
+
+  public attr(s: string, val: object) {
+    switch (s) {
+      case 'row':
+        this.options.rows = Number(val);
+        if (this.currentLayout == 1) this.planeLayout();
+        if (this.currentLayout == 2) this.cylinderLayout();
+        if (this.currentLayout == 3) this.sphereLayout();
+        break;
+      case 'margin':
+        let newmargin = val as Vector2;
+        this.options.margin = newmargin;
+        if (this.currentLayout == 1) this.planeLayout();
+        if (this.currentLayout == 2) this.cylinderLayout();
+        if (this.currentLayout == 3) this.sphereLayout();
+        break;
+      case 'radius':
+        this.options.radius = Number(val);
+        if (this.currentLayout == 2) this.cylinderLayout();
+        if (this.currentLayout == 3) this.sphereLayout();
+        break;
+      default:
+        break;
     }
+    return this;
+  }
 
-    public planeLayout(){
-        this.currentLayout = 1;
-        let rownum = this.options.rows || 1
-        let margin = this.options.margin || new Vector2(0, 0)
-        let chartnum = this.options.selection.selected.length
-        let boundingBox = this.boundingBoxLocal(this.options.selection)
-        let widthX = boundingBox.boundingBox.maximumWorld.x - boundingBox.boundingBox.minimumWorld.x;
-        let widthY = boundingBox.boundingBox.maximumWorld.y - boundingBox.boundingBox.minimumWorld.y;
-        let colnum = this.options.columns || chartnum;
+  // public zalign(){
+  //     let boundingBox = this.boundingBoxLocal(this.options.selection)
+  //     let widthZ = boundingBox.boundingBox.maximumWorld.z - boundingBox.boundingBox.minimumWorld.z;
+  //     this.options.selection.selected.forEach((node, i) => {
+  //         let test = new Selection([this.options.selection.selected[i]], this.scene);
+  //         let zSize = this.boundingBoxLocal(test).boundingBox.maximumWorld.z - this.boundingBoxLocal(test).boundingBox.minimumWorld.z;
+  //         this.animatePosition((node as TransformNode), new Vector3((node as TransformNode).position.x, (node as TransformNode).position.y, zSize / 2 - widthZ / 2));
+  //     })
+  //     return this;
+  // }
 
-        colnum = chartnum % rownum == 0 ? chartnum / rownum : Math.floor(chartnum / rownum) + 1;
-        
-        this.options.selection.selected.forEach((node, i) => {
-            //(node.parent as Mesh).showBoundingBox = showBox;
-            node.parent = this.root;
-            this.animatePosition((node as TransformNode), new Vector3((i % colnum - ((colnum-1) / 2.0)) * (widthX + margin.x), Math.floor(i / colnum) * (widthY + margin.y), 0));
-            this.animateRotation((node as TransformNode), new Vector3(0, 0, 0))
-        })
-        
-        return this;
-    }
+  public update() {
+    if (this.currentLayout == 1) this.planeLayout();
+    if (this.currentLayout == 2) this.cylinderLayout();
+    if (this.currentLayout == 3) this.sphereLayout();
 
-    public cylinderLayout(){
-        this.currentLayout = 2;
-        let rownum = this.options.rows || 1
-        let margin = this.options.margin || new Vector2(0,0)
-        let chartnum = this.options.selection.selected.length
-        let boundingBox = this.boundingBoxLocal(this.options.selection)
-        let radius = this.options.radius || 5
-        let widthX = boundingBox.boundingBox.maximumWorld.x - boundingBox.boundingBox.minimumWorld.x;
-        let widthY = boundingBox.boundingBox.maximumWorld.y - boundingBox.boundingBox.minimumWorld.y;
-        let colnum = this.options.columns || chartnum;
+    return this;
+  }
 
-        colnum = chartnum % rownum == 0 ? chartnum / rownum : Math.floor(chartnum / rownum) + 1;
+  private animatePosition(obj: TransformNode, newPos: Vector3) {
+    var animationBezierTorus = new Animation(
+      'animationBezierTorus',
+      'position',
+      30,
+      Animation.ANIMATIONTYPE_VECTOR3,
+      Animation.ANIMATIONLOOPMODE_CONSTANT,
+    );
+    var keysBezierTorus = [];
+    keysBezierTorus.push({ frame: 0, value: obj.position });
+    keysBezierTorus.push({ frame: 20, value: newPos });
+    animationBezierTorus.setKeys(keysBezierTorus);
+    var bezierEase = new BezierCurveEase(0.73, 0, 0.31, 1);
+    animationBezierTorus.setEasingFunction(bezierEase);
+    obj.animations.length = Math.min(obj.animations.length, 2);
+    obj.animations.push(animationBezierTorus);
+    this.scene.beginDirectAnimation(obj, [animationBezierTorus], 0, 20, false);
+  }
 
-        let angle = Math.atan(widthX / 2 / radius) * 2 / Math.PI * 180;
+  private animateRotation(obj: TransformNode, newRot: Vector3) {
+    //check if quaternion is null, if so we use eulerangle
+    //helper convert Quaternion.eulerangle
+    //set quaternion to null when using rotation, but not the other way
+    let keys = [];
+    keys.push({ frame: 0, value: (obj as TransformNode).rotation });
+    keys.push({ frame: 20, value: newRot });
+    let animation = new Animation(
+      '',
+      'rotation',
+      20,
+      Animation.ANIMATIONTYPE_VECTOR3,
+      Animation.ANIMATIONLOOPMODE_CYCLE,
+    );
+    animation.setKeys(keys);
+    var bezierEase = new BezierCurveEase(0.73, 0, 0.31, 1);
+    animation.setEasingFunction(bezierEase);
+    this.scene.beginDirectAnimation(obj, [animation], 0, 20, false);
+  }
 
-        let forward = new Vector3(0, 0, 1);
-        let up = new Vector3(0, 1, 0);
-        
-        this.options.selection.selected.forEach((node, i) => {
-            node.parent = this.root;
-            this.animateRotation((node as TransformNode), new Vector3(0, 0, 0));
-            let origin = new Mesh("vect", this.scene);
-            origin.position = new Vector3(0, 0, 0);
-            let rowid = Math.floor(i / colnum);
-            let colid = i % colnum;
-            origin.rotate(new Vector3(0, 1, 0), colid * (angle + margin.x) * Math.PI / 180);
-            let originforward = origin.getDirection(forward).normalize();
-            let pos = originforward.multiplyByFloats(radius, radius, radius);
-            let newPos = new Vector3(pos.x,  rowid * (widthY + margin.y), pos.z)
-            this.animatePosition((node as TransformNode), newPos);
-            let newRot = origin.rotationQuaternion?.toEulerAngles() || new Vector3(0, 0, 0);
-            this.animateRotation((node as TransformNode), newRot);
-            origin.dispose();
-        })
+  private animateScale(obj: TransformNode, newScale: Vector3) {
+    var animationBezierTorus = new Animation(
+      'animationBezierTorus',
+      'scaling',
+      30,
+      Animation.ANIMATIONTYPE_VECTOR3,
+      Animation.ANIMATIONLOOPMODE_CONSTANT,
+    );
+    var keysBezierTorus = [];
+    keysBezierTorus.push({ frame: 0, value: obj.scaling });
+    keysBezierTorus.push({ frame: 10, value: newScale });
+    animationBezierTorus.setKeys(keysBezierTorus);
+    var bezierEase = new BezierCurveEase(0.73, 0, 0.31, 1);
+    animationBezierTorus.setEasingFunction(bezierEase);
+    obj.animations.length = Math.min(obj.animations.length, 2);
+    obj.animations.push(animationBezierTorus);
+    this.scene.beginDirectAnimation(obj, [animationBezierTorus], 0, 10, true);
+  }
 
-        return this;
-    }
+  private boundingBoxLocal(selection: Selection): BoundingInfo {
+    let selectionMin = new Vector3(0, 0, 0);
+    let selectionMax = new Vector3(0, 0, 0);
 
-    public sphereLayout(){
-        this.currentLayout = 3;
-        let rownum = this.options.rows || 1
-        let margin = this.options.margin || new Vector2(0,0)
-        let chartnum = this.options.selection.selected.length
-        let boundingBox = this.boundingBoxLocal(this.options.selection)
-        let radius = this.options.radius || 5
-        let widthX = boundingBox.boundingBox.maximumWorld.x - boundingBox.boundingBox.minimumWorld.x;
-        let widthY = boundingBox.boundingBox.maximumWorld.y - boundingBox.boundingBox.minimumWorld.y;
-        let colnum = this.options.columns || chartnum;
+    selection.selected.forEach((node, i) => {
+      let meshes = node.getChildMeshes();
+      meshes.forEach((mesh, j) => {
+        mesh.computeWorldMatrix(true); //without this the bounding box is calulcated at the mesh creation position...TODO investigate.
+        let nodeMin = mesh
+          .getBoundingInfo()
+          .boundingBox.minimumWorld.subtract((node as TransformNode).getAbsolutePosition());
+        let nodeMax = mesh
+          .getBoundingInfo()
+          .boundingBox.maximumWorld.subtract((node as TransformNode).getAbsolutePosition());
+        selectionMin = Vector3.Minimize(selectionMin, nodeMin);
+        selectionMax = Vector3.Maximize(selectionMax, nodeMax);
+      });
+    });
 
-        colnum = chartnum % rownum == 0 ? chartnum / rownum : Math.floor(chartnum / rownum) + 1;
-
-        let angle = Math.atan(widthX / 2 / radius) * 2 * 180 / Math.PI;
-        let angleY = Math.atan(widthY / 2 / radius) * 2 * 180 / Math.PI;
-        
-        this.options.selection.selected.forEach((node, i) => {            
-            //make a 3D coord using spherical coordinate system
-            node.parent = this.root;
-            let colid = Math.floor(i / colnum) - Math.floor(rownum / 2);
-            let rowid = i % colnum - Math.floor(colnum / 2);
-            let anglephi = Math.min(colid * (angle + margin.y), 360) * Math.PI / 180;
-            let angletheta = Math.min(Math.abs(90 - rowid * (angleY + margin.x)), 180) * Math.PI / 180;
-            let newPos = new Vector3(radius * Math.sin(angletheta) * Math.cos(anglephi), radius * Math.sin(angletheta) * Math.sin(anglephi), radius * Math.cos(angletheta));
-            this.animatePosition((node as TransformNode), newPos);
-            let newRot = new Vector3(-anglephi, angletheta, 0);
-            this.animateRotation((node as TransformNode), newRot);
-        })
-
-        return this;
-    }
-    
-
-    public attr(s: string, val: object){
-        switch(s){
-            case "row":
-                this.options.rows = Number(val);
-                if(this.currentLayout == 1)
-                    this.planeLayout();
-                if(this.currentLayout == 2)
-                    this.cylinderLayout();
-                if(this.currentLayout == 3)
-                    this.sphereLayout();
-                break;
-            case "margin":
-                let newmargin = val as Vector2;
-                    this.options.margin = newmargin;
-                if(this.currentLayout == 1)
-                    this.planeLayout();
-                if(this.currentLayout == 2)
-                    this.cylinderLayout();
-                if(this.currentLayout == 3)
-                    this.sphereLayout();
-                break;
-            case "radius":
-                this.options.radius = Number(val);
-                if(this.currentLayout == 2)
-                    this.cylinderLayout();
-                if(this.currentLayout == 3)
-                    this.sphereLayout();
-                break;
-            default:
-                break;
-        }
-        return this;
-    }
-
-
-    // public zalign(){
-    //     let boundingBox = this.boundingBoxLocal(this.options.selection)
-    //     let widthZ = boundingBox.boundingBox.maximumWorld.z - boundingBox.boundingBox.minimumWorld.z;
-    //     this.options.selection.selected.forEach((node, i) => {
-    //         let test = new Selection([this.options.selection.selected[i]], this.scene);
-    //         let zSize = this.boundingBoxLocal(test).boundingBox.maximumWorld.z - this.boundingBoxLocal(test).boundingBox.minimumWorld.z;
-    //         this.animatePosition((node as TransformNode), new Vector3((node as TransformNode).position.x, (node as TransformNode).position.y, zSize / 2 - widthZ / 2));
-    //     })
-    //     return this;
-    // }
-
-    
-    public update(){
-        if(this.currentLayout == 1)
-            this.planeLayout();
-        if(this.currentLayout == 2)
-            this.cylinderLayout();
-        if(this.currentLayout == 3)
-            this.sphereLayout();
-
-        return this;
-    }
-
-    private animatePosition(obj: TransformNode, newPos: Vector3){
-        var animationBezierTorus = new Animation("animationBezierTorus", "position", 30, Animation.ANIMATIONTYPE_VECTOR3, Animation.ANIMATIONLOOPMODE_CONSTANT);
-        var keysBezierTorus = [];
-        keysBezierTorus.push({ frame: 0, value: obj.position });
-        keysBezierTorus.push({ frame: 20, value: newPos });
-        animationBezierTorus.setKeys(keysBezierTorus);
-        var bezierEase = new BezierCurveEase(0.73, 0, 0.31, 1);
-        animationBezierTorus.setEasingFunction(bezierEase);
-        obj.animations.length = Math.min(obj.animations.length, 2);
-        obj.animations.push(animationBezierTorus);
-        this.scene.beginDirectAnimation(obj, [animationBezierTorus], 0, 20, false);
-    }
-
-    private animateRotation(obj: TransformNode, newRot: Vector3){
-        //check if quaternion is null, if so we use eulerangle
-        //helper convert Quaternion.eulerangle
-        //set quaternion to null when using rotation, but not the other way
-        let keys = [];
-        keys.push({frame:0, value: (obj as TransformNode).rotation});
-        keys.push({frame:20, value: newRot});
-        let animation = new Animation("", "rotation", 20, 
-        Animation.ANIMATIONTYPE_VECTOR3, Animation.ANIMATIONLOOPMODE_CYCLE);
-        animation.setKeys(keys);
-        var bezierEase = new BezierCurveEase(0.73, 0, 0.31, 1);
-        animation.setEasingFunction(bezierEase);
-        this.scene.beginDirectAnimation(obj, [animation], 0, 20, false);
-    }
-
-    private animateScale(obj: TransformNode, newScale: Vector3){
-        var animationBezierTorus = new Animation("animationBezierTorus", "scaling", 30, Animation.ANIMATIONTYPE_VECTOR3, Animation.ANIMATIONLOOPMODE_CONSTANT);
-        var keysBezierTorus = [];
-        keysBezierTorus.push({ frame: 0, value: obj.scaling });
-        keysBezierTorus.push({ frame: 10, value: newScale });
-        animationBezierTorus.setKeys(keysBezierTorus);
-        var bezierEase = new BezierCurveEase(0.73, 0, 0.31, 1);
-        animationBezierTorus.setEasingFunction(bezierEase);
-        obj.animations.length = Math.min(obj.animations.length, 2);        
-        obj.animations.push(animationBezierTorus);
-        this.scene.beginDirectAnimation(obj, [animationBezierTorus], 0, 10, true);
-    }
-
-    private boundingBoxLocal(selection: Selection): BoundingInfo {
-
-        let selectionMin = new Vector3(0, 0, 0);
-        let selectionMax = new Vector3(0, 0, 0);
-
-        selection.selected.forEach((node, i) => {
-        let meshes = node.getChildMeshes();
-        meshes.forEach((mesh, j) => {
-            mesh.computeWorldMatrix(true); //without this the bounding box is calulcated at the mesh creation position...TODO investigate.
-            let nodeMin = mesh.getBoundingInfo().boundingBox.minimumWorld.subtract((node as TransformNode).getAbsolutePosition());
-            let nodeMax = mesh.getBoundingInfo().boundingBox.maximumWorld.subtract((node as TransformNode).getAbsolutePosition());
-            selectionMin = Vector3.Minimize(selectionMin, nodeMin);
-            selectionMax = Vector3.Maximize(selectionMax, nodeMax);
-            });
-        });
-
-        return new BoundingInfo(selectionMin, selectionMax);
-    }
-    
+    return new BoundingInfo(selectionMin, selectionMax);
+  }
 }
 
 export function planeLayout(name: string, options: LayoutOptions, scene: Scene): Layout {
+  const Options: LayoutOptions = {
+    selection: options.selection,
+    rows: options.rows || 1,
+    columns: options.columns || options.selection.selected.length,
+    margin: options.margin || new Vector2(0, 0),
+    order: options.order || [],
+  };
 
-    const Options: LayoutOptions = {
-        selection: options.selection,
-        rows: options.rows || 1,
-        columns: options.columns || options.selection.selected.length,
-        margin: options.margin || new Vector2(0, 0),
-        order: options.order || [],
-    }
- 
-    return new Layout(name, Options, scene).planeLayout();
-
+  return new Layout(name, Options, scene).planeLayout();
 }
 
-export function cylinderLayout(name: string, options: LayoutOptions, scene: Scene){
+export function cylinderLayout(name: string, options: LayoutOptions, scene: Scene) {
+  const Options: LayoutOptions = {
+    selection: options.selection,
+    rows: options.rows || 1,
+    columns: options.columns || options.selection.selected.length,
+    radius: options.radius || 5,
+    margin: options.margin || new Vector2(0, 0),
+    order: options.order || [],
+  };
 
-    const Options: LayoutOptions = {
-        selection: options.selection,
-        rows: options.rows || 1,
-        columns: options.columns || options.selection.selected.length,
-        radius: options.radius || 5,
-        margin: options.margin || new Vector2(0, 0),
-        order: options.order || [],
-    }
- 
-    return new Layout(name, Options, scene).cylinderLayout();
-
+  return new Layout(name, Options, scene).cylinderLayout();
 }
 
 export function sphereLayout(name: string, options: LayoutOptions, scene: Scene): Layout {
+  const Options: LayoutOptions = {
+    selection: options.selection,
+    rows: options.rows || 1,
+    columns: options.columns || options.selection.selected.length,
+    margin: options.margin || new Vector2(0, 0),
+    order: options.order || [],
+  };
 
-    const Options: LayoutOptions = {
-        selection: options.selection,
-        rows: options.rows || 1,
-        columns: options.columns || options.selection.selected.length,
-        margin: options.margin || new Vector2(0, 0),
-        order: options.order || [],
-    }
- 
-    return new Layout(name, Options, scene).sphereLayout();
-
+  return new Layout(name, Options, scene).sphereLayout();
 }
 
-export function cockpitLayout(){}
+export function cockpitLayout() {}

--- a/src/prefabs/Mapping/MeshMap.ts
+++ b/src/prefabs/Mapping/MeshMap.ts
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright : J.P. Morgan Chase & Co.
 
-import { Vector3, Scene,  MeshBuilder, Mesh, TransformNode, Nullable, Node} from '@babylonjs/core';
+import { Vector3, Scene, MeshBuilder, Mesh, TransformNode, Nullable, Node } from '@babylonjs/core';
 import { GeoGeometryObjects, GeoProjection, geoAlbers, geoIdentity } from 'd3-geo';
-import * as topojsonClient from "topojson-client";
-import * as topojsonSimplify from "topojson-simplify";
-import * as topojsonServer from "topojson-server";
-import earcut from "earcut";
-import { geoProject } from "d3-geo-projection";
+import * as topojsonClient from 'topojson-client';
+import * as topojsonSimplify from 'topojson-simplify';
+import * as topojsonServer from 'topojson-server';
+import earcut from 'earcut';
+import { geoProject } from 'd3-geo-projection';
 import { Selection } from '../../selection';
 
 export class MeshMap extends TransformNode {
@@ -22,8 +22,17 @@ export class MeshMap extends TransformNode {
   selection?: Selection;
   depth?: number;
 
-  constructor(name: string, geoJson: GeoGeometryObjects, projection: GeoProjection, size: [number, number], transform: [number, number], simplification: number, depth: number, scene?: Scene) {
-    super(name, scene, true)
+  constructor(
+    name: string,
+    geoJson: GeoGeometryObjects,
+    projection: GeoProjection,
+    size: [number, number],
+    transform: [number, number],
+    simplification: number,
+    depth: number,
+    scene?: Scene,
+  ) {
+    super(name, scene, true);
     this.geoJson = geoJson;
     this.projection = projection;
     this.size = size;
@@ -34,9 +43,11 @@ export class MeshMap extends TransformNode {
     this.selection = this.createMap();
   }
 
-  createMap(): Selection{
-
-    let preProjection = geoProject(this.geoJson, this.projection.fitSize(this.size, this.geoJson).translate(this.transform));
+  createMap(): Selection {
+    let preProjection = geoProject(
+      this.geoJson,
+      this.projection.fitSize(this.size, this.geoJson).translate(this.transform),
+    );
     let geoProjection = geoProject(preProjection, geoIdentity());
     let topoJson = topojsonServer.topology({ features: geoProjection });
     let preSimpleTopoJson = topojsonSimplify.presimplify(topoJson as any);
@@ -46,40 +57,52 @@ export class MeshMap extends TransformNode {
     let mesh;
     let states: any[] = [];
 
-    (simpleGeojson as any).features.forEach((features: {
-      properties: null; geometry: { type: string; coordinates: any[]; } | null; 
-}) => { 
-    if (features.geometry != null) {
-        if (features.geometry.type === "Polygon"){
-        let path: Vector3[] = []
-        features.geometry.coordinates[0].forEach((coord: (number | undefined)[]) => path.push(new Vector3(coord[0], 0, coord[1])))
-        mesh = MeshBuilder.ExtrudePolygon("polygon", {shape: path, depth: this.depth, wrap: false, sideOrientation: 2}, this.scene, earcut);
-        mesh!.name = "polygon"
-        mesh!.parent = this.cot;
-        mesh!.metadata = { ...mesh!.metadata, data: (features.properties != null) ? features.properties : null };
-        states.push(mesh);
-        } else if (features.geometry.type === "MultiPolygon") {
-        let meshes: Mesh[] = []
-        features.geometry.coordinates.forEach(coords => {
-            coords.forEach((coord: any[]) => {
-            let path: Vector3[] = []
-            coord.forEach((coord: (number | undefined)[]) => path.push(new Vector3(coord[0], 0, coord[1])))
-            meshes.push(MeshBuilder.ExtrudePolygon("polygon", {shape: path, depth: this.depth, wrap: false, sideOrientation: 2}, this.scene, earcut));
-        })
-        })
-        mesh = Mesh.MergeMeshes(meshes, true, true);
-        mesh!.name = "polygon"
-        mesh!.parent = this.cot;
-        mesh!.metadata = { ...mesh!.metadata, data: (features.properties != null) ? features.properties : null};
-        states.push(mesh)
+    (simpleGeojson as any).features.forEach(
+      (features: { properties: null; geometry: { type: string; coordinates: any[] } | null }) => {
+        if (features.geometry != null) {
+          if (features.geometry.type === 'Polygon') {
+            let path: Vector3[] = [];
+            features.geometry.coordinates[0].forEach((coord: (number | undefined)[]) =>
+              path.push(new Vector3(coord[0], 0, coord[1])),
+            );
+            mesh = MeshBuilder.ExtrudePolygon(
+              'polygon',
+              { shape: path, depth: this.depth, wrap: false, sideOrientation: 2 },
+              this.scene,
+              earcut,
+            );
+            mesh!.name = 'polygon';
+            mesh!.parent = this.cot;
+            mesh!.metadata = { ...mesh!.metadata, data: features.properties != null ? features.properties : null };
+            states.push(mesh);
+          } else if (features.geometry.type === 'MultiPolygon') {
+            let meshes: Mesh[] = [];
+            features.geometry.coordinates.forEach((coords) => {
+              coords.forEach((coord: any[]) => {
+                let path: Vector3[] = [];
+                coord.forEach((coord: (number | undefined)[]) => path.push(new Vector3(coord[0], 0, coord[1])));
+                meshes.push(
+                  MeshBuilder.ExtrudePolygon(
+                    'polygon',
+                    { shape: path, depth: this.depth, wrap: false, sideOrientation: 2 },
+                    this.scene,
+                    earcut,
+                  ),
+                );
+              });
+            });
+            mesh = Mesh.MergeMeshes(meshes, true, true);
+            mesh!.name = 'polygon';
+            mesh!.parent = this.cot;
+            mesh!.metadata = { ...mesh!.metadata, data: features.properties != null ? features.properties : null };
+            states.push(mesh);
+          }
         }
-    }
-    });
-    
+      },
+    );
+
     return new Selection(states, this.scene);
   }
-
-
 }
 
 export function createMeshMap(
@@ -95,15 +118,14 @@ export function createMeshMap(
   },
   scene?: Scene,
 ) {
+  const geoJson = options.geoJson;
+  const projection = options.projection || geoAlbers();
+  const size = options.size || [10, 10];
+  const transform = options.transform || [0, 0];
+  const simplification = options.simplification || 0;
+  const depth = options.depth || 1;
 
-    const geoJson = options.geoJson;
-    const projection = options.projection || geoAlbers();
-    const size = options.size || [10,10];
-    const transform = options.transform || [0,0];
-    const simplification = options.simplification || 0;
-    const depth = options.depth || 1;
-  
-    let map = new  MeshMap(name, geoJson, projection, size, transform, simplification, depth, scene);
+  let map = new MeshMap(name, geoJson, projection, size, transform, simplification, depth, scene);
 
   return map;
 }

--- a/src/prefabs/Mapping/textureGlobe.ts
+++ b/src/prefabs/Mapping/textureGlobe.ts
@@ -17,11 +17,10 @@ import {
   Vector3,
   Space,
   Axis,
-  TransformNode
+  TransformNode,
 } from '@babylonjs/core';
 import { Context } from 'vm';
 import { Coordinate } from 'ol/coordinate';
-
 
 export class TextureGlobe extends TransformNode {
   name: string;
@@ -38,8 +37,15 @@ export class TextureGlobe extends TransformNode {
   diameter: number;
   lonLatToVector3: Function;
 
-  constructor(name: string, layers: TileLayer<OSM>[], view: View, resolution: Vector2, diameter: number, scene?: Scene,) {
-    super(name, scene, true)
+  constructor(
+    name: string,
+    layers: TileLayer<OSM>[],
+    view: View,
+    resolution: Vector2,
+    diameter: number,
+    scene?: Scene,
+  ) {
+    super(name, scene, true);
     this.layers = layers;
     this.target = 'globe';
     this.view = view;
@@ -93,13 +99,13 @@ export class TextureGlobe extends TransformNode {
   }
 
   createMesh() {
-    let globe = MeshBuilder.CreateSphere(this.name + "_mesh", { diameter: this.diameter }, this.scene);
+    let globe = MeshBuilder.CreateSphere(this.name + '_mesh', { diameter: this.diameter }, this.scene);
     globe.setParent(this);
     globe.rotate(Axis.X, Math.PI, Space.WORLD);
     globe.rotate(Axis.Y, Math.PI, Space.WORLD);
     let materialGlobe = new StandardMaterial(this.name + '_material', this.scene);
 
-    globe.bakeCurrentTransformIntoVertices()
+    globe.bakeCurrentTransformIntoVertices();
 
     materialGlobe.diffuseTexture = this.texture;
     materialGlobe.specularColor = new Color3(0, 0, 0);
@@ -109,10 +115,10 @@ export class TextureGlobe extends TransformNode {
   }
 
   createScales(c: Coordinate) {
-    let lon = (c[0]) * Math.PI / 180; 
-    let lat = (c[1]) * Math.PI / 180; 
+    let lon = (c[0] * Math.PI) / 180;
+    let lat = (c[1] * Math.PI) / 180;
 
-    let r = (this.diameter / 2);
+    let r = this.diameter / 2;
 
     let x = r * Math.cos(lat) * Math.cos(lon);
     let y = r * Math.cos(lat) * Math.sin(lon);
@@ -133,7 +139,7 @@ export function createTextureGlobe(
   scene?: Scene,
 ) {
   const layers: TileLayer<any>[] = options.layers || [
-    new TileLayer({ source: new OSM(), extent: [-180, -90, 180, 90] })
+    new TileLayer({ source: new OSM(), extent: [-180, -90, 180, 90] }),
   ];
   const view: View =
     options.view ||
@@ -141,7 +147,7 @@ export function createTextureGlobe(
       projection: 'EPSG:4326',
       extent: [-180, -90, 180, 90],
       center: [0, 0],
-      zoom: 0
+      zoom: 0,
     });
 
   const resolution: Vector2 = options.resolution || new Vector2(1000, 500);

--- a/src/prefabs/Mapping/textureMap.ts
+++ b/src/prefabs/Mapping/textureMap.ts
@@ -21,7 +21,7 @@ import {
 import { Context } from 'vm';
 import { Coordinate } from 'ol/coordinate';
 
-export class TextureMap extends TransformNode{
+export class TextureMap extends TransformNode {
   name: string;
   scene?: Scene;
   layers: TileLayer<OSM>[];
@@ -45,7 +45,7 @@ export class TextureMap extends TransformNode{
     size: number,
     scene?: Scene,
   ) {
-    super(name, scene, true)
+    super(name, scene, true);
     this.layers = layers;
     this.target = 'map2D';
     this.view = view;
@@ -106,12 +106,15 @@ export class TextureMap extends TransformNode{
     let ratio = this.resolution.width / this.resolution.height;
 
     let ground = MeshBuilder.CreateGround(
-      this.name + "_mesh",
+      this.name + '_mesh',
       { width: this.size * ratio, height: this.size, subdivisions: 25 },
       this.scene,
     );
     ground.setParent(this);
-    let materialGround = new StandardMaterial(this.name + '_material', (this.scene != undefined) ? this.scene : undefined);
+    let materialGround = new StandardMaterial(
+      this.name + '_material',
+      this.scene != undefined ? this.scene : undefined,
+    );
 
     materialGround.diffuseTexture = this.texture;
     materialGround.specularColor = new Color3(0, 0, 0);
@@ -137,7 +140,6 @@ export class TextureMap extends TransformNode{
   }
 
   keyboardControls(scene: Scene) {
-   
     scene.onKeyboardObservable.add((kbInfo) => {
       switch (kbInfo.type) {
         case KeyboardEventTypes.KEYDOWN:

--- a/src/prefabs/Misc/container.ts
+++ b/src/prefabs/Misc/container.ts
@@ -1,43 +1,41 @@
-import { Nullable, AbstractMesh, Scene, Mesh, BoundingInfo, Vector3 } from "@babylonjs/core";
+import { Nullable, AbstractMesh, Scene, Mesh, BoundingInfo, Vector3 } from '@babylonjs/core';
 
 interface containerOptions {
-    calculateBounds?: boolean,
-    exclude?: Nullable<(abstractMesh: AbstractMesh) => boolean> | undefined,
-    childObserver?: boolean,
+  calculateBounds?: boolean;
+  exclude?: Nullable<(abstractMesh: AbstractMesh) => boolean> | undefined;
+  childObserver?: boolean;
+}
+
+export function createContainer(name: string, options: containerOptions, scene: Scene) {
+  let calculateBounds = options.calculateBounds || true;
+  let exclude = options.exclude || undefined;
+  let childObserver = options.childObserver || false;
+
+  let container: Mesh = new Mesh(name, scene);
+
+  if (calculateBounds) {
+    let { min, max } = container.getHierarchyBoundingVectors(true, exclude);
+    container.setBoundingInfo(new BoundingInfo(min, max));
   }
 
-export function createContainer(name: string, options: containerOptions, scene: Scene){
-    let calculateBounds = options.calculateBounds || true;
-    let exclude = options.exclude || undefined;
-    let childObserver = options.childObserver || false; 
-  
-    let container: Mesh = new Mesh(name, scene);
-  
-    if (calculateBounds){
-      let { min, max } = container.getHierarchyBoundingVectors(true, exclude);
-      container.setBoundingInfo(new BoundingInfo(min, max));
-    }
-    
-    if (childObserver){
-      container.onAfterWorldMatrixUpdateObservable.add(() => {
-          setTimeout(() => {
-              if ((container as any).detectReentrancy) {
-                  return;
-              }
-              (container as any).detectReentrancy = true;
-              let { min, max } = container.getHierarchyBoundingVectors(true, exclude); //triggers observable causing infinite loop
-              const worldInv = container.getWorldMatrix().clone().invert();
-              Vector3.TransformCoordinatesToRef(min, worldInv, min);
-              Vector3.TransformCoordinatesToRef(max, worldInv, max);
-              container.setBoundingInfo(new BoundingInfo(min, max));
-              setTimeout(() => {
-                (container as any).detectReentrancy = false;
-              });
-          });
-      })
-    }
-    
-    return container
+  if (childObserver) {
+    container.onAfterWorldMatrixUpdateObservable.add(() => {
+      setTimeout(() => {
+        if ((container as any).detectReentrancy) {
+          return;
+        }
+        (container as any).detectReentrancy = true;
+        let { min, max } = container.getHierarchyBoundingVectors(true, exclude); //triggers observable causing infinite loop
+        const worldInv = container.getWorldMatrix().clone().invert();
+        Vector3.TransformCoordinatesToRef(min, worldInv, min);
+        Vector3.TransformCoordinatesToRef(max, worldInv, max);
+        container.setBoundingInfo(new BoundingInfo(min, max));
+        setTimeout(() => {
+          (container as any).detectReentrancy = false;
+        });
+      });
+    });
   }
 
-
+  return container;
+}

--- a/src/prefabs/Prefab.ts
+++ b/src/prefabs/Prefab.ts
@@ -1,40 +1,33 @@
-import { TransformNode } from "@babylonjs/core/Meshes/transformNode"
-import { Selection } from "../selection/index"
-import { Scene } from "@babylonjs/core/scene";
-import { Node } from "@babylonjs/core/node";
+import { TransformNode } from '@babylonjs/core/Meshes/transformNode';
+import { Selection } from '../selection/index';
+import { Scene } from '@babylonjs/core/scene';
+import { Node } from '@babylonjs/core/node';
 import { assign } from 'lodash-es';
-import { AbstractMesh, Mesh } from "@babylonjs/core";
+import { AbstractMesh, Mesh } from '@babylonjs/core';
 
-export class Prefab extends Mesh{ 
-    public name: string;
-    public scene: Scene;
-    public readonly cot: TransformNode;
-    public _parent?: Node | Selection;
-   
-    constructor(name: string, scene: Scene){
-        super(name, scene)
-        // this.name = name; 
-        // this.scene = scene
-        // this.cot = new TransformNode(name, scene)
-    }
+export class Prefab extends Mesh {
+  public name: string;
+  public scene: Scene;
+  public readonly cot: TransformNode;
+  public _parent?: Node | Selection;
 
-    // get parent(){
-    //     return this._parent;
-    // }
+  constructor(name: string, scene: Scene) {
+    super(name, scene);
+    // this.name = name;
+    // this.scene = scene
+    // this.cot = new TransformNode(name, scene)
+  }
 
-    // set parent(node: Node | Selection){
-    //     this._parent = (node instanceof Selection) ? node.selected[0] : node;
-    //     this.cot.setParent(this._parent);
-    // }
+  // get parent(){
+  //     return this._parent;
+  // }
 
-    // public dispose(){
-    //     this.cot.dispose(false, true);
-    // }
+  // set parent(node: Node | Selection){
+  //     this._parent = (node instanceof Selection) ? node.selected[0] : node;
+  //     this.cot.setParent(this._parent);
+  // }
 
-
-    
-
-   
-    
-
+  // public dispose(){
+  //     this.cot.dispose(false, true);
+  // }
 }

--- a/src/prefabs/Text/planeText.ts
+++ b/src/prefabs/Text/planeText.ts
@@ -2,9 +2,9 @@
 // Copyright : J.P. Morgan Chase & Co.
 
 import { Scene, Vector3, Color3, Mesh, Matrix, PlaneBlock } from '@babylonjs/core';
-import fnt from "../../assets/roboto-regular.json";
-import png from "../../assets/roboto-regular.png";
-import { createTextMesh } from "babylon-msdf-text";
+import fnt from '../../assets/roboto-regular.json';
+import png from '../../assets/roboto-regular.png';
+import { createTextMesh } from 'babylon-msdf-text';
 
 interface planeTextOptions {
   text: string;
@@ -12,7 +12,7 @@ interface planeTextOptions {
   font: any;
   atlas: any;
   opacity: number;
-  align: "left" | "right" | "center";
+  align: 'left' | 'right' | 'center';
   color: Color3;
 }
 
@@ -22,7 +22,7 @@ export class PlaneText {
   scene: Scene;
   mesh: Mesh;
 
-  constructor(name: string, options: planeTextOptions, scene: Scene){
+  constructor(name: string, options: planeTextOptions, scene: Scene) {
     this.name = name;
     this.options = options;
     this.scene = scene;
@@ -30,62 +30,48 @@ export class PlaneText {
   }
 
   run() {
+    let cot = new Mesh(this.name);
 
-  let cot = new Mesh(this.name);
+    let plane = createTextMesh({
+      text: this.options.text.toString(),
+      color: this.options.color,
+      opacity: this.options.opacity,
+      align: this.options.align,
+      font: this.options.font,
+      scene: cot.getScene(),
+      atlas: this.options.atlas,
+      lineHeight: 1,
+    });
 
-  let plane = createTextMesh({
-    text: this.options.text.toString(),
-    color: this.options.color,
-    opacity: this.options.opacity,
-    align: this.options.align,
-    font: this.options.font,
-    scene: cot.getScene(),
-    atlas: this.options.atlas,
-    lineHeight: 1,
-  });
+    let alignment =
+      this.options.align == 'left' ? 0 : this.options.align == 'center' ? 1 : this.options.align == 'right' ? 2 : null;
 
-  let alignment = (this.options.align == "left")? 0 :
-                  (this.options.align == "center")? 1 : 
-                  (this.options.align == "right")? 2 : null
+    plane.scaling = new Vector3(0.015, 0.015, 1);
+    plane.rotation.x = (180 * Math.PI) / 180;
+    plane.bakeCurrentTransformIntoVertices();
+    plane.computeWorldMatrix(true);
+    let size = plane.getBoundingInfo().boundingBox;
+    const translation = plane.position.subtract(new Vector3(size.center.x * alignment, size.center.y, 0));
+    plane.setPivotMatrix(Matrix.Translation(translation.x, 0, 0), false);
+    plane.setParent(cot);
+    cot.scaling = new Vector3(this.options.size, this.options.size, 1);
 
-
-
-  plane.scaling = new Vector3(0.015, 0.015, 1);
-  plane.rotation.x = 180 * Math.PI / 180;
-  plane.bakeCurrentTransformIntoVertices();
-  plane.computeWorldMatrix(true);
-  let size = plane.getBoundingInfo().boundingBox;
-  const translation = plane.position.subtract(new Vector3(size.center.x * alignment , size.center.y, 0))
-  plane.setPivotMatrix(Matrix.Translation(translation.x, 0, 0), false);
-  plane.setParent(cot);
-  cot.scaling = new Vector3(this.options.size,this.options.size,1);
-
-  return cot;
-
+    return cot;
   }
-
-
 }
 
-export function createPlaneText(
-  name: string,
-  options: planeTextOptions,
-  scene: Scene,
-) {
+export function createPlaneText(name: string, options: planeTextOptions, scene: Scene) {
   const ops = {
     text: options.text || 'undefined',
     size: options.size || 1,
     opacity: options.opacity || 1,
-    align: options.align || "center",
+    align: options.align || 'center',
     color: options.color || Color3.White(),
-    font: options.font|| fnt,
-    atlas: options.atlas || png
-  }
+    font: options.font || fnt,
+    atlas: options.atlas || png,
+  };
 
   let plane = new PlaneText(name, ops, scene);
 
   return plane.mesh;
-  
 }
-
-

--- a/src/select.ts
+++ b/src/select.ts
@@ -91,7 +91,7 @@ export function selectTag(tag: string | string[], scene: Scene) {
  * instance of Selection.
  *
  * @param key the key or list of keys of the nodes to be selected.
- * @param value the value or list of values corresponding to the respective key(s) passed. 
+ * @param value the value or list of values corresponding to the respective key(s) passed.
  * @param scene The babylon scene the to select from.
  * @returns an instance of Selection, a class contating a array of selected nodes, the scene, and the functions of the class Selection,
  * or undefined if a selection could not be made.

--- a/src/selection/animation/transition.ts
+++ b/src/selection/animation/transition.ts
@@ -1,19 +1,19 @@
-import { Animation, Scene, EasingFunction, Node} from '@babylonjs/core';
+import { Animation, Scene, EasingFunction, Node } from '@babylonjs/core';
 import { Selection } from '../index';
 import get from 'lodash-es/get';
 import hasIn from 'lodash-es/hasIn';
+import { delay } from 'lodash-es';
 
 
 
 export type TransitionOptions = {
-  duration?: number;
-  delay?: number;
-  framePerSecond?: number,
+  duration?: number; //done
+  delay?: number; //done
+  framePerSecond?: number, //done
   merge?: Boolean,
-  easingFunction?: EasingFunction,
-  loopMode?: number
-  onAnimationEnd?: () => void,
-  scene?: Scene,
+  easingFunction?: EasingFunction, //done
+  loopMode?: 0 | 1 | 2 | 3 | 4, //done but bug?
+  onAnimationEnd?: () => void
 } 
 
 
@@ -47,14 +47,28 @@ export function transition(this: Selection, options: TransitionOptions | ((d: an
 export function createTransition(selection: Selection, accessor: string, value: any) {
       selection.selected.forEach((node, i) => {
         let transitionOptions: TransitionOptions = selection.transitionOptions[i];
-        console.log(transitionOptions)
-        let duration = transitionOptions.duration || 1;
+        
+        let duration = (transitionOptions.duration || 250) / 1000;
+
         let fps: number = transitionOptions.framePerSecond || 30;
-        console.log(fps)
-        let frames: number = fps * duration
-        hasIn(node, accessor)
-          ? Animation.CreateAndStartAnimation(node.name + '_animation', node, accessor, fps , frames, get(node, accessor), value instanceof Function ? value(node.metadata.data ??= {}, node, i) : value)
+        let delay: number = transitionOptions.delay || 0;
+        let frames: number = fps * duration;
+        let loop: number = transitionOptions.loopMode || Animation.ANIMATIONLOOPMODE_CONSTANT
+        let ease: EasingFunction = transitionOptions.easingFunction || undefined;
+        let merge: Boolean = transitionOptions.merge || true;
+        let onEnd: () => void = transitionOptions.onAnimationEnd || undefined;
+        
+        setTimeout(() => { hasIn(node, accessor)
+          ? (async () => {
+            let animatable = Animation.CreateAndStartAnimation(node.name + '_animation', node, accessor, fps , frames, get(node, accessor), value instanceof Function ? value(node.metadata.data ??= {}, node, i) : value, loop, ease, onEnd)
+            let promise = animatable.waitAsync().then(() => {
+              
+            })
+          })()
           : console.error(accessor + ' not a property of ' + node);
+        }, delay)
+      
+
       });
   }
 

--- a/src/selection/animation/transition.ts
+++ b/src/selection/animation/transition.ts
@@ -70,10 +70,10 @@ export function createTransition(selection: Selection, accessor: string, value: 
         let onEnd: () => void = transitionOptions.onAnimationEnd || undefined;
         let animatable = Animation.CreateAndStartAnimation(node.name + '_animation', node, accessor, fps , frames, get(node, accessor), value instanceof Function ? value(node.metadata.data ??= {}, node, i) : value, loop, ease, onEnd)
         animatable.pause();
+        animatable.reset();
         let promise: Promise<Animatable> = animatable.waitAsync()
         selection.transitions[sequence].animatables.push(promise)
         if (sequence !== 0 && wait) await selection.transitions[Math.max(0, sequence - 1)].animatables[i];
-        animatable.reset();
         setTimeout(() => animatable.restart(), delay);
       });
   }

--- a/src/selection/animation/transition.ts
+++ b/src/selection/animation/transition.ts
@@ -101,28 +101,20 @@ export function tween(this: Selection, value: (d,n,i) => (t) => void) {
     let onEnd: () => void = transitionOptions.onAnimationEnd || undefined;
     let func = value(node.metadata.data ??= {}, node, i);
    
-
-    // Variables to control the movement
     let startTime = null;
 
-  
-    // Register a function to be called before each render
     let transition = scene.onBeforeRenderObservable.add(() => {
         if (startTime === null) {
             startTime = performance.now();
         }
     
-        // Calculate the elapsed time
         var elapsedTime = performance.now() - startTime;
     
-        // Calculate the fraction of the duration that has passed
-        var fraction = Math.min(elapsedTime / duration, 1);
+        var lerpTime = Math.min(elapsedTime / duration, 1);
     
-        // Update the box's position
-        func(fraction)
-    
-        // Stop updating after the duration has passed
-        if (fraction === 1) {
+        func(lerpTime)
+
+        if (lerpTime === 1) {
             scene.onBeforeRenderObservable.remove(transition);
         }
     });

--- a/src/selection/animation/transition.ts
+++ b/src/selection/animation/transition.ts
@@ -1,0 +1,61 @@
+import { Animation, Scene, EasingFunction, Node} from '@babylonjs/core';
+import { Selection } from '../index';
+import get from 'lodash-es/get';
+import hasIn from 'lodash-es/hasIn';
+
+
+
+export type TransitionOptions = {
+  duration: number;
+  delay?: number;
+  framePerSecond?: number,
+  merge?: Boolean,
+  easingFunction?: EasingFunction,
+  onAnimationEnd?: () => void,
+  scene?: Scene,
+} 
+| 
+{
+  framePerSecond: number,
+  totalFrame: number,
+  delay?: number;
+  loopMode?: number,
+  merge?: Boolean,
+  easingFunction?: EasingFunction,
+  onAnimationEnd?: () => void,
+  scene?: Scene,
+}
+
+
+/**
+ * Called from a selection this method allows you to set any property or subproperty of nodes in the selection given that property exists.
+ *
+ * @param accessor The name of the property to be set (e.g. "renderingGroupId", "material.alpha").
+ * @param value The value to set the property or a function(d, i) returing the value for said property with scope of the binded data "d", mesh "m", and the index "i".
+ * @returns The modified selection
+ */
+export function transition(this: Selection, options: TransitionOptions | ((d: any, n: Node, i: number) => TransitionOptions)){
+  this.selected.forEach((node, i) => {
+    this.setTransitionOptions(options instanceof Function ? options(node.metadata.data ??= {}, node, i) : options)
+  });
+
+  return this;
+}
+
+
+/**
+ * Called from a selection this method allows you to set any property or subproperty of nodes in the selection given that property exists.
+ *
+ * @param accessor The name of the property to be set (e.g. "renderingGroupId", "material.alpha").
+ * @param value The value to set the property or a function(d, i) returing the value for said property with scope of the binded data "d", mesh "m", and the index "i".
+ * @returns The modified selection
+ */
+export function createTransition(selection: Selection, accessor: string, value: any) {
+      selection.selected.forEach((node, i) => {
+        hasIn(node, accessor)
+          ? Animation.CreateAndStartAnimation(node.name + '_animation', node, accessor, 1 , 1, get(node, accessor), value instanceof Function ? value(node.metadata.data ??= {}, node, i) : value)
+          : console.error(accessor + ' not a property of ' + node);
+      });
+  }
+
+

--- a/src/selection/animation/transition.ts
+++ b/src/selection/animation/transition.ts
@@ -1,143 +1,149 @@
-import { Animation, Scene, EasingFunction, Node, Animatable, Tools } from '@babylonjs/core';
+import { Animation, EasingFunction, Node, Animatable } from '@babylonjs/core';
 import { Selection } from '../index';
 import get from 'lodash-es/get';
-import hasIn from 'lodash-es/hasIn';
-
 
 export type TransitionOptions = {
   duration?: number; //done
   delay?: number; //done
-  framePerSecond?: number, //done
-  sequence?: boolean,
-  easingFunction?: EasingFunction, //done
-  loopMode?: 0 | 1 | 2 | 3 | 4, //done but bug?
-  onAnimationEnd?: () => void
-} 
+  framePerSecond?: number; //done
+  sequence?: boolean;
+  easingFunction?: EasingFunction; //done
+  loopMode?: 0 | 1 | 2 | 3 | 4; //done but bug?
+  onAnimationEnd?: () => void;
+};
 
 export class Transition {
   sequence: number;
   transitionOptions: TransitionOptions[];
   animatables?: Promise<Animatable>[];
 
-  constructor(sequence: number, transitionOptions: TransitionOptions[]){
+  constructor(sequence: number, transitionOptions: TransitionOptions[]) {
     this.sequence = sequence;
     this.transitionOptions = transitionOptions;
     this.animatables = [];
   }
-
-  
 }
 
-
-
 /**
- * Called from a selection this method allows you to set any property or subproperty of nodes in the selection given that property exists.
+ * Initiates and returns a new transition selection object or adds a new transition sequence to an existing transition selection object. This method is called from a selection and is used to animate the change in transforms of each node in the selection. The transition can be customized using the provided options or a function that returns options for each node.
  *
- * @param accessor The name of the property to be set (e.g. "renderingGroupId", "material.alpha").
- * @param value The value to set the property or a function(d, i) returing the value for said property with scope of the binded data "d", mesh "m", and the index "i".
- * @returns The modified selection
+ * @param options - The transition options to apply. This can be a `TransitionOptions` object or a function that returns a `TransitionOptions` object for each node. The function receives the data bound to the node, the node itself, and the index of the node as arguments.
+ *
+ * TransitionOptions:
+ * - `duration` (optional): The duration of the transition in milliseconds.
+ * - `delay` (optional): The delay before the transition starts, in milliseconds.
+ * - `framePerSecond` (optional): The number of frames per second for the transition.
+ * - `sequence` (optional): A boolean indicating whether the transition should be part of a sequence.
+ * - `easingFunction` (optional): An easing function to control the transition's rate of change.
+ * - `loopMode` (optional): A number (0 to 4) indicating the loop mode for the transition.
+ * - `onAnimationEnd` (optional): A callback function to be executed when the transition ends.
+ *
+ * @returns The modified transition selection.
  */
-export function transition(this: Selection, options: TransitionOptions | ((d: any, n: Node, i: number) => TransitionOptions)){
+export function transition(
+  this: Selection,
+  options: TransitionOptions | ((d: any, n: Node, i: number) => TransitionOptions),
+) {
   let executedOptions = new Array<TransitionOptions>();
-  this.selected.forEach((node, i) => {
-    executedOptions.push(options instanceof Function ? options(node.metadata.data ??= {}, node, i) : options || {})
+  let transitionSelection: Selection;
+  if (this.transitions.length === 0) {
+    transitionSelection = new Selection(this.selected, this.scene);
+  } else {
+    transitionSelection = this;
+  }
+  transitionSelection.selected.forEach((node, i) => {
+    executedOptions.push(options instanceof Function ? options((node.metadata.data ??= {}), node, i) : options || {});
   });
-  
-  let transition = new Transition(this.transitions.length, executedOptions);
-  this.updateTransitions(transition);
 
-  return this;
+  let transition = new Transition(this.transitions.length, executedOptions);
+  transitionSelection.updateTransitions(transition);
+
+  return transitionSelection;
 }
 
-
 /**
- * Called from a selection this method allows you to set any property or subproperty of nodes in the selection given that property exists.
+ * Creates and starts a transition animation for each node in the given selection. The transition is configured using the options specified in the selection's current transition sequence. This function handles the setup of animation parameters such as duration, frames per second, delay, loop mode, and easing function.
  *
- * @param accessor The name of the property to be set (e.g. "renderingGroupId", "material.alpha").
- * @param value The value to set the property or a function(d, i) returing the value for said property with scope of the binded data "d", mesh "m", and the index "i".
- * @returns The modified selection
+ * @param selection - The selection of nodes to which the transition will be applied. Each node in the selection will have its property animated according to the specified options.
+ * @param accessor - The name of the property to be animated (e.g., "position", "rotation").
+ * @param value - The target value for the property. This can be a static value or a function that returns a value for each node. If a function is provided, it receives the data bound to the node, the node itself, and the index of the node as arguments.
  */
 export function createTransition(selection: Selection, accessor: string, value: any) {
-      let sequence = selection.transitions.length - 1; 
-      selection.selected.forEach(async (node, i) => {
-        let transitionOptions: TransitionOptions = selection.transitions[sequence].transitionOptions[i];
-        let duration = (transitionOptions.duration || 250) / 1000;
-        let fps: number = transitionOptions.framePerSecond || 30;
-        let delay: number = transitionOptions.delay || 0;
-        let frames: number = fps * duration;
-        let loop: number = transitionOptions.loopMode || Animation.ANIMATIONLOOPMODE_CONSTANT
-        let ease: EasingFunction = transitionOptions.easingFunction || undefined;
-        let wait: boolean = transitionOptions.sequence ??= true;
-        let onEnd: () => void = transitionOptions.onAnimationEnd || undefined;
-        let animatable = Animation.CreateAndStartAnimation(node.name + '_animation', node, accessor, fps , frames, get(node, accessor), value instanceof Function ? value(node.metadata.data ??= {}, node, i) : value, loop, ease, onEnd)
-        animatable.pause();
-        animatable.reset();
-        let promise: Promise<Animatable> = animatable.waitAsync()
-        selection.transitions[sequence].animatables.push(promise)
-        if (sequence !== 0 && wait) await selection.transitions[Math.max(0, sequence - 1)].animatables[i];
-        setTimeout(() => animatable.restart(), delay);
-      });
-  }
+  let sequence = selection.transitions.length - 1;
+  selection.selected.forEach(async (node, i) => {
+    let transitionOptions: TransitionOptions = selection.transitions[sequence].transitionOptions[i];
+    let duration = (transitionOptions.duration || 250) / 1000;
+    let fps: number = transitionOptions.framePerSecond || 30;
+    let delay: number = transitionOptions.delay || 0;
+    let frames: number = fps * duration;
+    let loop: number = transitionOptions.loopMode || Animation.ANIMATIONLOOPMODE_CONSTANT;
+    let ease: EasingFunction = transitionOptions.easingFunction || undefined;
+    let wait: boolean = (transitionOptions.sequence ??= true);
+    let onEnd: () => void = transitionOptions.onAnimationEnd || undefined;
+    let animatable = Animation.CreateAndStartAnimation(
+      node.name + '_animation',
+      node,
+      accessor,
+      fps,
+      frames,
+      get(node, accessor),
+      value instanceof Function ? value((node.metadata.data ??= {}), node, i) : value,
+      loop,
+      ease,
+      onEnd,
+    );
+    animatable.pause();
+    animatable.reset();
+    let promise: Promise<Animatable> = animatable.waitAsync();
+    selection.transitions[sequence].animatables.push(promise);
+    if (sequence !== 0 && wait) await selection.transitions[Math.max(0, sequence - 1)].animatables[i];
+    setTimeout(() => animatable.restart(), delay);
+  });
+}
 
 /**
- * Called from a selection this method allows you to set any property or subproperty of nodes in the selection given that property exists.
+ * Applies a tweening function to each node in the selection, returning a eased time value between 0-1 to be used for animation control for the total duration of the transition. The tweening function is executed for each node, allowing for fine-grained control over the animation process.
  *
- * @param accessor The name of the property to be set (e.g. "renderingGroupId", "material.alpha").
- * @param value The value to set the property or a function(d, i) returing the value for said property with scope of the binded data "d", mesh "m", and the index "i".
- * @returns The modified selection
+ * @param value - A function that returns a tweening function for each node. The outer function receives the data bound to the node, the node itself, and the index of the node as arguments. The returned tweening function is called with a parameter `t` that represents the normalized time (from 0 to 1) of the animation.
+ *
+ * @returns The modified selection with the applied tweening animations.
  */
-export function tween(this: Selection, value: (d,n,i) => (t) => void) {
-  let sequence = this.transitions.length - 1; 
+export function tween(this: Selection, value: (d, n, i) => (t) => void) {
+  let sequence = this.transitions.length - 1;
   let scene = this.scene;
   this.selected.forEach(async (node, i) => {
     let transitionOptions: TransitionOptions = this.transitions[sequence].transitionOptions[i];
-    let duration = (transitionOptions.duration || 250);
+    let duration = transitionOptions.duration || 250;
     //let fps: number = transitionOptions.framePerSecond || 30;
     let delay: number = transitionOptions.delay || 0;
     //let loop: number = transitionOptions.loopMode || Animation.ANIMATIONLOOPMODE_CONSTANT
     let ease: EasingFunction = transitionOptions.easingFunction || undefined;
-    let wait: boolean = transitionOptions.sequence ??= true;
+    let wait: boolean = (transitionOptions.sequence ??= true);
     let onEnd: () => void = transitionOptions.onAnimationEnd || undefined;
-    let func = value(node.metadata.data ??= {}, node, i);
+    let func = value((node.metadata.data ??= {}), node, i);
     let startTime = null;
     let accumulatedTime = 0;
-    
+
     let animatable: Animatable = new Animatable(scene, node, undefined, undefined, undefined, undefined, onEnd);
     animatable.pause();
-    let promise: Promise<Animatable> = animatable.waitAsync()
-    this.transitions[sequence].animatables.push(promise)
+    let promise: Promise<Animatable> = animatable.waitAsync();
+    this.transitions[sequence].animatables.push(promise);
     if (sequence !== 0 && wait) await this.transitions[Math.max(0, sequence - 1)].animatables[i];
     setTimeout(() => {
       let transition = scene.onBeforeRenderObservable.add(() => {
-        if (startTime === null)  startTime = performance.now();
+        if (startTime === null) startTime = performance.now();
 
         let elapsedTime = performance.now() - startTime;
         let lerpTime = Math.min(elapsedTime / duration, 1);
 
-   
-    
-        
-        func((ease) ? ease.ease(lerpTime) : lerpTime);
-  
+        func(ease ? ease.ease(lerpTime) : lerpTime);
 
         if (lerpTime === 1) {
           scene.onBeforeRenderObservable.remove(transition);
           animatable.stop();
-        };
-
-        
+        }
       });
     }, delay);
-    
-    
-  
-
   });
+  return this;
 }
-  
-  
-  
-  
-
-
-

--- a/src/selection/bind/bind.ts
+++ b/src/selection/bind/bind.ts
@@ -17,7 +17,12 @@ type Property<T, MeshType extends keyof T> = T[MeshType];
  * @returns An instance of Selection, a class containing a array of selected nodes, the scene, and the functions of the class Selection,
  * or undefined if a selection could not be made.
  */
-export function bind<MeshType extends keyof MeshTypes>(this: Selection, shape: MeshType, options: Property<MeshTypes, MeshType> = {}, data: Array<object> = [{}]): Selection {
+export function bind<MeshType extends keyof MeshTypes>(
+  this: Selection,
+  shape: MeshType,
+  options: Property<MeshTypes, MeshType> = {},
+  data: Array<object> = [{}],
+): Selection {
   let meshes: Node[] = [];
   this.selected.forEach((node) => {
     data.forEach((element, i) => {
@@ -74,8 +79,8 @@ export function bindThinInstance(this: Selection, mesh: Mesh, data: Array<object
       let matrix = Matrix.Identity();
       matrix.copyToArray(matrices, i * 16);
     });
-    instance.thinInstanceSetBuffer("matrix", matrices, 16, false);
-    meshes.push(instance)
+    instance.thinInstanceSetBuffer('matrix', matrices, 16, false);
+    meshes.push(instance);
   });
   return new Selection(meshes, this.scene);
 }

--- a/src/selection/bind/bind.ts
+++ b/src/selection/bind/bind.ts
@@ -67,6 +67,7 @@ export function bindInstance(this: Selection, mesh: Mesh, data: Array<object> = 
 export function bindThinInstance(this: Selection, mesh: Mesh, data: Array<object> = [{}]): Selection {
   let meshes: Node[] = [];
   this.selected.forEach((node, i) => {
+    //node.metadata = { ...node.metadata, data: data };
     let instance = mesh.clone(mesh.name + '_' + i, node);
     let matrices = new Float32Array(16 * data.length * 3);
     data.forEach((element, i) => {

--- a/src/selection/index.ts
+++ b/src/selection/index.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright : J.P. Morgan Chase & Co.
 
-import { Node, Mesh, TransformNode, InstancedMesh } from '@babylonjs/core';
+import { Node, Mesh, TransformNode, InstancedMesh, AbstractMesh, Nullable } from '@babylonjs/core';
 import { Scene } from '@babylonjs/core/scene';
 import { select, selectName, selectId, selectTag, selectData } from './utility/select';
 import { bind, bindInstance, bindThinInstance } from './bind/bind';
@@ -37,6 +37,7 @@ import { thinInstanceSetBuffer, thinInstancePosition, thinInstanceScaling, thinI
   thinInstancePositionAt, thinInstanceScalingAt, thinInstanceRotationAt, thinInstanceColorAt,
   thinInstancePositionFor, thinInstanceScalingFor, thinInstanceRotationFor, thinInstanceColorFor
 } from './property/thin';
+import { TransitionOptions, transition } from './animation/transition';
 
 /*
     The core class of anujs. All functions should return 
@@ -45,12 +46,18 @@ import { thinInstanceSetBuffer, thinInstancePosition, thinInstanceScaling, thinI
     The selection class also exposes all of anus core functions. 
 */
 export class Selection {
-  selected: Node[] | TransformNode[] | Mesh[];
+  selected: Node[] | TransformNode[] | Mesh[] | AbstractMesh[];
   scene?: Scene;
+  transitionOptions?: TransitionOptions;
 
-  constructor(nodes: Node[] | TransformNode[] | Mesh[], scene?: Scene) {
+  constructor(nodes: Node[] | TransformNode[] | Mesh[] | AbstractMesh[], scene?: Scene, transitionOptions?: TransitionOptions) {
     this.selected = nodes;
     this.scene = scene;
+    this.transitionOptions = transitionOptions;
+  }
+
+  public setTransitionOptions(options: TransitionOptions){
+    this.transitionOptions = options;
   }
 
   public select = select;
@@ -124,5 +131,6 @@ export class Selection {
   public thinInstanceRotationFor = thinInstanceRotationFor;
   public thinInstanceColorFor = thinInstanceColorFor;
   public bindThinInstance = bindThinInstance;
+  public transition = transition;
 
 }

--- a/src/selection/index.ts
+++ b/src/selection/index.ts
@@ -37,7 +37,7 @@ import { thinInstanceSetBuffer, thinInstancePosition, thinInstanceScaling, thinI
   thinInstancePositionAt, thinInstanceScalingAt, thinInstanceRotationAt, thinInstanceColorAt,
   thinInstancePositionFor, thinInstanceScalingFor, thinInstanceRotationFor, thinInstanceColorFor
 } from './property/thin';
-import { TransitionOptions, transition } from './animation/transition';
+import { TransitionOptions, transition, Transition } from './animation/transition';
 
 /*
     The core class of anujs. All functions should return 
@@ -48,16 +48,17 @@ import { TransitionOptions, transition } from './animation/transition';
 export class Selection {
   selected: Node[] | TransformNode[] | Mesh[] | AbstractMesh[];
   scene?: Scene;
-  transitionOptions?: TransitionOptions[];
+  transitions: Transition[];
+ 
 
-  constructor(nodes: Node[] | TransformNode[] | Mesh[] | AbstractMesh[], scene?: Scene, transitionOptions?: TransitionOptions[]) {
+  constructor(nodes: Node[] | TransformNode[] | Mesh[] | AbstractMesh[], scene?: Scene) {
     this.selected = nodes;
     this.scene = scene;
-    this.transitionOptions = transitionOptions;
+    this.transitions = [];
   }
 
-  public setTransitionOptions(options: TransitionOptions[]){
-    this.transitionOptions = options;
+  public updateTransitions(transition: Transition){
+    this.transitions.push(transition);
   }
 
   public select = select;

--- a/src/selection/index.ts
+++ b/src/selection/index.ts
@@ -37,7 +37,7 @@ import { thinInstanceSetBuffer, thinInstancePosition, thinInstanceScaling, thinI
   thinInstancePositionAt, thinInstanceScalingAt, thinInstanceRotationAt, thinInstanceColorAt,
   thinInstancePositionFor, thinInstanceScalingFor, thinInstanceRotationFor, thinInstanceColorFor
 } from './property/thin';
-import { TransitionOptions, transition, Transition } from './animation/transition';
+import { transition, Transition, tween } from './animation/transition';
 
 /*
     The core class of anujs. All functions should return 
@@ -133,5 +133,6 @@ export class Selection {
   public thinInstanceColorFor = thinInstanceColorFor;
   public bindThinInstance = bindThinInstance;
   public transition = transition;
+  public tween = tween;
 
 }

--- a/src/selection/index.ts
+++ b/src/selection/index.ts
@@ -48,15 +48,15 @@ import { TransitionOptions, transition } from './animation/transition';
 export class Selection {
   selected: Node[] | TransformNode[] | Mesh[] | AbstractMesh[];
   scene?: Scene;
-  transitionOptions?: TransitionOptions;
+  transitionOptions?: TransitionOptions[];
 
-  constructor(nodes: Node[] | TransformNode[] | Mesh[] | AbstractMesh[], scene?: Scene, transitionOptions?: TransitionOptions) {
+  constructor(nodes: Node[] | TransformNode[] | Mesh[] | AbstractMesh[], scene?: Scene, transitionOptions?: TransitionOptions[]) {
     this.selected = nodes;
     this.scene = scene;
     this.transitionOptions = transitionOptions;
   }
 
-  public setTransitionOptions(options: TransitionOptions){
+  public setTransitionOptions(options: TransitionOptions[]){
     this.transitionOptions = options;
   }
 

--- a/src/selection/index.ts
+++ b/src/selection/index.ts
@@ -32,10 +32,25 @@ import { boundingBox } from './utility/boundingBox';
 import { filter } from './utility/filter';
 import { name, id, metadata } from './property/metadata';
 import { positionUI, rotateUI, scaleUI } from '../prefabs/Interactions/facetPosition';
-import { thinInstanceSetBuffer, thinInstancePosition, thinInstanceScaling, thinInstanceRotation, thinInstanceColor, 
-  thinInstanceRegisterAttribute, thinInstanceSetAttribute, thinInstanceAttributeAt, thinInstanceMatrixAt, thinInstanceMatrixFor,
-  thinInstancePositionAt, thinInstanceScalingAt, thinInstanceRotationAt, thinInstanceColorAt,
-  thinInstancePositionFor, thinInstanceScalingFor, thinInstanceRotationFor, thinInstanceColorFor
+import {
+  thinInstanceSetBuffer,
+  thinInstancePosition,
+  thinInstanceScaling,
+  thinInstanceRotation,
+  thinInstanceColor,
+  thinInstanceRegisterAttribute,
+  thinInstanceSetAttribute,
+  thinInstanceAttributeAt,
+  thinInstanceMatrixAt,
+  thinInstanceMatrixFor,
+  thinInstancePositionAt,
+  thinInstanceScalingAt,
+  thinInstanceRotationAt,
+  thinInstanceColorAt,
+  thinInstancePositionFor,
+  thinInstanceScalingFor,
+  thinInstanceRotationFor,
+  thinInstanceColorFor,
 } from './property/thin';
 import { transition, Transition, tween } from './animation/transition';
 
@@ -49,7 +64,6 @@ export class Selection {
   selected: Node[] | TransformNode[] | Mesh[] | AbstractMesh[];
   scene?: Scene;
   transitions: Transition[];
- 
 
   constructor(nodes: Node[] | TransformNode[] | Mesh[] | AbstractMesh[], scene?: Scene) {
     this.selected = nodes;
@@ -57,7 +71,7 @@ export class Selection {
     this.transitions = [];
   }
 
-  public updateTransitions(transition: Transition){
+  public updateTransitions(transition: Transition) {
     this.transitions.push(transition);
   }
 
@@ -119,7 +133,7 @@ export class Selection {
   public thinInstanceRotation = thinInstanceRotation;
   public thinInstanceColor = thinInstanceColor;
   public thinInstanceSetAttribute = thinInstanceSetAttribute;
-  public thinInstanceAttributeAt = thinInstanceAttributeAt
+  public thinInstanceAttributeAt = thinInstanceAttributeAt;
   public thinInstanceRegisterAttribute = thinInstanceRegisterAttribute;
   public thinInstanceMatrixAt = thinInstanceMatrixAt;
   public thinInstanceMatrixFor = thinInstanceMatrixFor;
@@ -134,5 +148,4 @@ export class Selection {
   public bindThinInstance = bindThinInstance;
   public transition = transition;
   public tween = tween;
-
 }

--- a/src/selection/property/actions.ts
+++ b/src/selection/property/actions.ts
@@ -11,7 +11,7 @@ export function action(this: Selection, action: Action | ((d: any, n: AbstractMe
   this.selected.forEach((node, i) => {
     node instanceof AbstractMesh
       ? action instanceof Function
-        ? node.actionManager?.registerAction(action(node.metadata.data ??= {}, node, i))
+        ? node.actionManager?.registerAction(action((node.metadata.data ??= {}), node, i))
         : node.actionManager?.registerAction(action)
       : console.log('Node not a mesh, skipping.');
   });

--- a/src/selection/property/prop.ts
+++ b/src/selection/property/prop.ts
@@ -35,7 +35,7 @@ export function attr(this: Selection, accessor: string, value: any) {
  * @returns The modified selection
  */
 export function prop(this: Selection, accessor: string, value: any) {
-  if (this.transition != undefined){
+  if (this.transition !== undefined){
     createTransition(this, accessor, value);
   } else {
     this.selected.forEach((node, i) => {

--- a/src/selection/property/prop.ts
+++ b/src/selection/property/prop.ts
@@ -20,7 +20,7 @@ export function attr(this: Selection, accessor: string, value: any) {
   this.selected.forEach((node, i) => {
     node instanceof TransformNode
       ? get(node, accessor) != undefined
-        ? set(node, accessor, value instanceof Function ? value(node.metadata.data ??= {}, i) : value)
+        ? set(node, accessor, value instanceof Function ? value((node.metadata.data ??= {}), i) : value)
         : console.error(accessor + ' not a property of ' + node)
       : console.warn('Node not a mesh, skipping.');
   });
@@ -35,12 +35,12 @@ export function attr(this: Selection, accessor: string, value: any) {
  * @returns The modified selection
  */
 export function prop(this: Selection, accessor: string, value: any) {
-  if (this.transitions.length > 0){
+  if (this.transitions.length > 0) {
     createTransition(this, accessor, value);
   } else {
     this.selected.forEach((node, i) => {
       hasIn(node, accessor)
-        ? set(node, accessor, value instanceof Function ? value(node.metadata.data ??= {}, node, i) : value)
+        ? set(node, accessor, value instanceof Function ? value((node.metadata.data ??= {}), node, i) : value)
         : console.error(accessor + ' not a property of ' + node);
     });
     return this;
@@ -49,7 +49,7 @@ export function prop(this: Selection, accessor: string, value: any) {
 
 /**
  * Called from a selection this method allows you to set multiple properties or subproperties of nodes in the selection given that property exists.
- * Use this method to improve performace when setting or changing many properties. 
+ * Use this method to improve performance when setting or changing many properties.
  *
  * @param properties Object of key value pairs for the properties to be set or changed, e.g., \{\"renderingGroupId": 2, "material.alpha": 0.2\}.
  * @returns The modified selection
@@ -57,15 +57,19 @@ export function prop(this: Selection, accessor: string, value: any) {
 export function props(this: Selection, properties: {}) {
   this.selected.forEach((node, i) => {
     for (let accessor in properties) {
-      hasIn(node, accessor)
-        ? set(
-            node,
-            accessor,
-            (properties as any)[accessor] instanceof Function
-              ? (properties as any)[accessor](node.metadata.data ??= {}, node, i)
-              : (properties as any)[accessor],
-          )
-        : console.log(accessor + ' not property of ' + node);
+      if (this.transitions.length > 0) {
+        createTransition(this, accessor, properties[accessor]);
+      } else {
+        hasIn(node, accessor)
+          ? set(
+              node,
+              accessor,
+              (properties as any)[accessor] instanceof Function
+                ? (properties as any)[accessor]((node.metadata.data ??= {}), node, i)
+                : (properties as any)[accessor],
+            )
+          : console.log(accessor + ' not property of ' + node);
+      }
     }
   });
 

--- a/src/selection/property/prop.ts
+++ b/src/selection/property/prop.ts
@@ -35,7 +35,7 @@ export function attr(this: Selection, accessor: string, value: any) {
  * @returns The modified selection
  */
 export function prop(this: Selection, accessor: string, value: any) {
-  if (this.transition !== undefined){
+  if (this.transitions.length > 0){
     createTransition(this, accessor, value);
   } else {
     this.selected.forEach((node, i) => {

--- a/src/selection/property/thin.ts
+++ b/src/selection/property/thin.ts
@@ -1,369 +1,453 @@
-import { Node, Mesh, Matrix, Vector3, Quaternion, Color4} from '@babylonjs/core';
+import { Node, Mesh, Matrix, Vector3, Quaternion, Color4 } from '@babylonjs/core';
 import { Selection } from '../index';
 
-export function thinInstanceSetBuffer(this: Selection, attribute: string, value: Float32Array | ((d: any, n: Node, i: number) => Float32Array), stride?: number, staticBuffer: boolean = false): Selection{
+export function thinInstanceSetBuffer(
+  this: Selection,
+  attribute: string,
+  value: Float32Array | ((d: any, n: Node, i: number) => Float32Array),
+  stride?: number,
+  staticBuffer: boolean = false,
+): Selection {
+  this.selected.forEach((node, i) => {
+    node instanceof Mesh
+      ? node.hasThinInstances
+        ? node.thinInstanceSetBuffer(
+            attribute,
+            value instanceof Function ? value((node.metadata.data ??= {}), node, i) : value,
+            stride,
+            staticBuffer,
+          )
+        : console.warn(node + 'has no thin instances, skipping')
+      : console.warn(node + 'Node is not a mesh, skipping');
+  });
 
-    this.selected.forEach((node, i) => {
-        node instanceof Mesh
-        ? node.hasThinInstances 
-            ? node.thinInstanceSetBuffer(attribute, value instanceof Function ? value(node.metadata.data ??= {}, node, i) : value, stride, staticBuffer)
-            : console.warn(node + "has no thin instances, skipping")
-        : console.warn(node + "Node is not a mesh, skipping");
-    })
-
-    return this;
+  return this;
 }
 
-export function thinInstancePosition(this: Selection, value: Vector3 | ((d: any, n: Node, i: number) => Vector3), staticBuffer: boolean = false): Selection{
-
-    this.selected.forEach((node, i) => {
-        node instanceof Mesh
-        ? node.hasThinInstances 
-            ?  (() => {
-                let bufferMatrices = new Float32Array(node.thinInstanceCount * 16);
-                let matrices = node.thinInstanceGetWorldMatrices();
-                let data = node.metadata.data ??={}
-                data.forEach((e, j) => {
-                    let evaluated = value instanceof Function ? value(e, node, j) : value
-                    let matrix = matrices[j].setTranslation(evaluated)
-                    matrix.copyToArray(bufferMatrices, j * 16);
-                });
-                node.thinInstanceSetBuffer("matrix", bufferMatrices, 16, staticBuffer)
-            })()
-            : console.warn(node + "has no thin instances, skipping")
-        : console.warn(node + "Node is not a mesh, skipping");
-    })
-
-    return this;
-}
-
-export function thinInstanceScaling(this: Selection, value: Vector3 | ((d: any, n: Node, i: number) => Vector3), staticBuffer: boolean = false): Selection{
-
-    this.selected.forEach((node, i) => {
-        node instanceof Mesh
-        ? node.hasThinInstances 
-            ?  (() => {
-                let bufferMatrices = new Float32Array(node.thinInstanceCount * 16);
-                let matrices = node.thinInstanceGetWorldMatrices();
-                let data = node.metadata.data ??={}
-                data.forEach((e, j) => {
-                    let evaluated = value instanceof Function ? value(e, node, j) : value
-                    let previousMatrix = matrices[j];
-                    let matrix =  Matrix.ComposeToRef(evaluated, Quaternion.FromRotationMatrix(previousMatrix.getRotationMatrix()), previousMatrix.getTranslation(), previousMatrix)
-                    matrix.copyToArray(bufferMatrices, j * 16);
-                   
-                });
-                node.thinInstanceSetBuffer("matrix", bufferMatrices, 16, staticBuffer)
-            })()
-            : console.warn(node + "has no thin instances, skipping")
-        : console.warn(node + "Node is not a mesh, skipping");
-    })
-
-    return this;
-}
-
-
-
-export function thinInstanceRotation(this: Selection, value: Vector3 | ((d: any, n: Node, i: number) => Vector3), staticBuffer: boolean = false): Selection{
-
-    this.selected.forEach((node, i) => {
-        node instanceof Mesh
-        ? node.hasThinInstances 
-            ?  (() => {
-                
-                let bufferMatrices = new Float32Array(node.thinInstanceCount * 16);
-                let matrices = node.thinInstanceGetWorldMatrices();
-                let data = node.metadata.data ??={}
-                data.forEach((e, j) => {
-                    let evaluated = value instanceof Function ? value(e, node, j) : value
-                    let previousMatrix = matrices[j];
-                    let previousScale = new Vector3;
-                    previousMatrix.decompose(previousScale)
-                    let matrix =  Matrix.ComposeToRef(previousScale, Quaternion.FromEulerVector(evaluated), previousMatrix.getTranslation(), previousMatrix)
-                    matrix.copyToArray(bufferMatrices, j * 16);
-                   
-                });
-                node.thinInstanceSetBuffer("matrix", bufferMatrices, 16, staticBuffer)
-            })()
-            : console.warn(node + "has no thin instances, skipping")
-        : console.warn(node + "Node is not a mesh, skipping");
-    })
-
-    return this;
-}
-
-export function thinInstanceColor(this: Selection, value: Color4 | ((d: any, n: Node, i: number) => Color4), staticBuffer: boolean = false): Selection{
-
-    this.selected.forEach((node, i) => {
-        if (node instanceof Mesh && node.hasThinInstances){
-            let colorMatrices = new Float32Array(node.thinInstanceCount * 4);
-            if (value instanceof Function){
-                let data = node.metadata.data ??= {};
-                data.forEach((e, j) => {
-                let evaluated = value(e,node,j)
-                colorMatrices[j * 4 + 0] = evaluated.r
-                colorMatrices[j * 4 + 1] = evaluated.g
-                colorMatrices[j * 4 + 2] = evaluated.b
-                colorMatrices[j * 4 + 3] = evaluated.a;
-                
-                });
-            } else {
-                for (let k = 0; k < node.thinInstanceCount; k++){
-                    colorMatrices[k * 4 + 0] = value.r
-                    colorMatrices[k * 4 + 1] = value.g
-                    colorMatrices[k * 4 + 2] = value.b
-                    colorMatrices[k * 4 + 3] = value.a;
-                }
-            }
-            node.thinInstanceSetBuffer("color", colorMatrices, 4, staticBuffer)
-        } else {
-            console.warn(node + "Node is not a mesh or has no thin instances, skipping");
-        }
-    })
-
-    return this;
-}
-
-export function thinInstanceRegisterAttribute(this: Selection, attribute: string, stride: number): Selection{
-
-    this.selected.forEach((node, i) => {
-        node instanceof Mesh
-        ? node.hasThinInstances 
-            ? node.thinInstanceRegisterAttribute(attribute, stride)
-            : console.warn(node + "has no thin instances, skipping")
-        : console.warn(node + "Node is not a mesh, skipping");
-    })
-
-    return this;
-}
-
-export function thinInstanceSetAttribute(this: Selection, attribute: string, value: any | ((d: any, n: Node, i: number) => any)): Selection{
-
-    this.selected.forEach((node, i) => {
-        node instanceof Mesh
-        ? node.hasThinInstances 
-            ? (node.metadata.data ??= {}).forEach((d,k) => {
-                node.thinInstanceSetAttributeAt(attribute, k, value instanceof Function ? value(node.metadata.data ??= {}, node, i) : value)
-            })
-            : console.warn(node + "has no thin instances, skipping")
-        : console.warn(node + "Node is not a mesh, skipping");
-    })
-
-    return this;
-}
-
-export function thinInstanceAttributeAt(this: Selection, attribute: string, index: number, value: any | ((d: any, n: Node, i: number) => any)): Selection{
-    this.selected.forEach((node, i) => {
-    
-        let evaluated = value instanceof Function ? value(node.metadata.data[index] ??= {}, node, index) : value
-
-        node instanceof Mesh
-        ? node.hasThinInstances 
-            ?  node.thinInstanceSetAttributeAt(attribute, index, value instanceof Function ? value(node.metadata.data ??= {}, node, i) : value)
-            : console.warn(node + "has no thin instances, skipping")
-        : console.warn(node + "Node is not a mesh, skipping");
-    })
-
-    return this;
-}
-
-export function thinInstanceMatrixAt(this: Selection, index: number, value: Matrix | ((d: any, n: Node, i: number) => Matrix)): Selection{
-    
-    this.selected.forEach((node, i) => {
-        let evaluated = value instanceof Function ? value(node.metadata.data[index] ??= {}, node, index) : value
-        node instanceof Mesh
-        ? node.hasThinInstances 
-            ?  node.thinInstanceSetMatrixAt(index, evaluated)
-            : console.warn(node + "has no thin instances, skipping")
-        : console.warn(node + "Node is not a mesh, skipping");
-    })
-
-    return this;
-}
-
-export function thinInstancePositionAt(this: Selection, index: number, value: Vector3 | ((d: any, n: Node, i: number) => Vector3)): Selection{
-
-    this.selected.forEach((node, i) => {
-        node instanceof Mesh
-        ? node.hasThinInstances 
-            ?  (() => {
-                let evaluated = value instanceof Function ? value(node.metadata.data[index] ??= {}, node, index) : value
-                let previousMatrix = node.thinInstanceGetWorldMatrices()[index];
-                let matrix = previousMatrix.setTranslation(evaluated);
-                node.thinInstanceSetMatrixAt(index, matrix)
-            })()
-            : console.warn(node + "has no thin instances, skipping")
-        : console.warn(node + "Node is not a mesh, skipping");
-    })
-
-    return this;
-}
-
-export function thinInstanceScalingAt(this: Selection, index: number, value: Vector3 | ((d: any, n: Node, i: number) => Vector3)): Selection{
-
-    this.selected.forEach((node, i) => {
-        node instanceof Mesh
-        ? node.hasThinInstances 
-            ?  (() => {
-                let evaluated = value instanceof Function ? value(node.metadata.data[index] ??= {}, node, index) : value
-                let previousMatrix = node.thinInstanceGetWorldMatrices()[index];
-                let matrix =  Matrix.ComposeToRef(evaluated, Quaternion.FromRotationMatrix(previousMatrix.getRotationMatrix()), previousMatrix.getTranslation(), previousMatrix)    
-                node.thinInstanceSetMatrixAt(index, matrix)
-            })()
-            : console.warn(node + "has no thin instances, skipping")
-        : console.warn(node + "Node is not a mesh, skipping");
-    })
-
-    return this;
-}
-
-export function thinInstanceRotationAt(this: Selection, index: number, value: Vector3 | ((d: any, n: Node, i: number) => Vector3)): Selection{
-
-    this.selected.forEach((node, i) => {
-        node instanceof Mesh
-        ? node.hasThinInstances 
-            ?  (() => {
-                let evaluated = value instanceof Function ? value(node.metadata.data[index] ??= {}, node, index) : value
-                let previousMatrix = node.thinInstanceGetWorldMatrices()[index];
-                let previousScale = new Vector3;
-                previousMatrix.decompose(previousScale)
-                let matrix =  Matrix.ComposeToRef(previousScale, Quaternion.FromEulerVector(evaluated), previousMatrix.getTranslation(), previousMatrix)
-                node.thinInstanceSetMatrixAt(index, matrix)
-            })()
-            : console.warn(node + "has no thin instances, skipping")
-        : console.warn(node + "Node is not a mesh, skipping");
-    })
-
-    return this;
-}
-
-
-export function thinInstanceColorAt(this: Selection, index: number, value: Color4 | ((d: any, n: Node, i: number) => Color4)): Selection{
-
-    this.selected.forEach((node, i) => {
-        node instanceof Mesh
-        ? node.hasThinInstances 
-            ?  (() => {
-                let evaluated = value instanceof Function ? value(node.metadata.data[index] ??= {}, node, index) : value
-                node.thinInstanceSetAttributeAt("color", index, [evaluated.r, evaluated.g, evaluated.b, evaluated.a])
-            })()
-            : console.warn(node + "has no thin instances, skipping")
-        : console.warn(node + "Node is not a mesh, skipping");
-    })
-
-    return this;
-}
-
-
-
-export function thinInstanceMatrixFor(this: Selection, method: (d: any, n: Node, i: number) => boolean, value: Matrix | ((d: any, n: Node, i: number) => Matrix)): Selection{
-
-    this.selected.forEach((node, i) => {
-        if (node instanceof Mesh && node.hasThinInstances){
-            let data = node.metadata.data ??= {};
-            (data).forEach((d, k) => {
-                if (method(d, node, k)) {
-                    node.thinInstanceSetMatrixAt(k, value instanceof Function ? value(node.metadata.data ??= {}, node, k) : value, false); 
-                }
-            });
-            node.thinInstanceSetMatrixAt(0, node.thinInstanceGetWorldMatrices()[0], true);
-        }
-        else  console.warn(node + "is not a mesh or has no thin instances, skipping");
-    
-    })
-
-    return this;
-}
-
-export function thinInstancePositionFor(this: Selection, method: (d: any, n: Node, i: number) => boolean, value: Vector3| ((d: any, n: Node, i: number) => Vector3)): Selection{
-
-    this.selected.forEach((node, i) => {
-        if (node instanceof Mesh && node.hasThinInstances){
+export function thinInstancePosition(
+  this: Selection,
+  value: Vector3 | ((d: any, n: Node, i: number) => Vector3),
+  staticBuffer: boolean = false,
+): Selection {
+  this.selected.forEach((node, i) => {
+    node instanceof Mesh
+      ? node.hasThinInstances
+        ? (() => {
             let bufferMatrices = new Float32Array(node.thinInstanceCount * 16);
             let matrices = node.thinInstanceGetWorldMatrices();
-            let data = node.metadata.data ??={}
+            let data = (node.metadata.data ??= {});
             data.forEach((e, j) => {
-                if (method(e, node, j)) {
-                    let evaluated = value instanceof Function ? value(e, node, j) : value
-                    let previousMatrix = node.thinInstanceGetWorldMatrices()[j];
-                    let matrix = previousMatrix.setTranslation(evaluated);
-                    node.thinInstanceSetMatrixAt(j, matrix, false)
-                }
+              let evaluated = value instanceof Function ? value(e, node, j) : value;
+              let matrix = matrices[j].setTranslation(evaluated);
+              matrix.copyToArray(bufferMatrices, j * 16);
             });
-           node.thinInstanceSetMatrixAt(0, node.thinInstanceGetWorldMatrices()[0], true);
-        }
-            else  console.warn(node + "is not a mesh or has no thin instances, skipping");
-    })
+            node.thinInstanceSetBuffer('matrix', bufferMatrices, 16, staticBuffer);
+          })()
+        : console.warn(node + 'has no thin instances, skipping')
+      : console.warn(node + 'Node is not a mesh, skipping');
+  });
 
-    return this;
+  return this;
 }
 
-export function thinInstanceRotationFor(this: Selection, method: (d: any, n: Node, i: number) => boolean, value: Vector3| ((d: any, n: Node, i: number) => Vector3)): Selection{
-
-    this.selected.forEach((node, i) => {
-        if (node instanceof Mesh && node.hasThinInstances){
+export function thinInstanceScaling(
+  this: Selection,
+  value: Vector3 | ((d: any, n: Node, i: number) => Vector3),
+  staticBuffer: boolean = false,
+): Selection {
+  this.selected.forEach((node, i) => {
+    node instanceof Mesh
+      ? node.hasThinInstances
+        ? (() => {
             let bufferMatrices = new Float32Array(node.thinInstanceCount * 16);
             let matrices = node.thinInstanceGetWorldMatrices();
-            let data = node.metadata.data ??={}
+            let data = (node.metadata.data ??= {});
             data.forEach((e, j) => {
-                if (method(e, node, j)) {
-                    let evaluated = value instanceof Function ? value(e, node, j) : value
-                    let previousMatrix = node.thinInstanceGetWorldMatrices()[j];
-                    let previousScale = new Vector3;
-                    previousMatrix.decompose(previousScale)
-                    let matrix =  Matrix.ComposeToRef(previousScale, Quaternion.FromEulerVector(evaluated), previousMatrix.getTranslation(), previousMatrix)
-                    node.thinInstanceSetMatrixAt(j, matrix, false)
-                }
+              let evaluated = value instanceof Function ? value(e, node, j) : value;
+              let previousMatrix = matrices[j];
+              let matrix = Matrix.ComposeToRef(
+                evaluated,
+                Quaternion.FromRotationMatrix(previousMatrix.getRotationMatrix()),
+                previousMatrix.getTranslation(),
+                previousMatrix,
+              );
+              matrix.copyToArray(bufferMatrices, j * 16);
             });
-           node.thinInstanceSetMatrixAt(0, node.thinInstanceGetWorldMatrices()[0], true);
-        }
-            else  console.warn(node + "is not a mesh or has no thin instances, skipping");
-    })
+            node.thinInstanceSetBuffer('matrix', bufferMatrices, 16, staticBuffer);
+          })()
+        : console.warn(node + 'has no thin instances, skipping')
+      : console.warn(node + 'Node is not a mesh, skipping');
+  });
 
-    return this;
+  return this;
 }
 
-export function thinInstanceScalingFor(this: Selection, method: (d: any, n: Node, i: number) => boolean, value: Vector3| ((d: any, n: Node, i: number) => Vector3)): Selection{
-
-    this.selected.forEach((node, i) => {
-        if (node instanceof Mesh && node.hasThinInstances){
+export function thinInstanceRotation(
+  this: Selection,
+  value: Vector3 | ((d: any, n: Node, i: number) => Vector3),
+  staticBuffer: boolean = false,
+): Selection {
+  this.selected.forEach((node, i) => {
+    node instanceof Mesh
+      ? node.hasThinInstances
+        ? (() => {
             let bufferMatrices = new Float32Array(node.thinInstanceCount * 16);
             let matrices = node.thinInstanceGetWorldMatrices();
-            let data = node.metadata.data ??={}
+            let data = (node.metadata.data ??= {});
             data.forEach((e, j) => {
-                if (method(e, node, j)) {
-                    let evaluated = value instanceof Function ? value(e, node, j) : value
-                    let previousMatrix = node.thinInstanceGetWorldMatrices()[j];
-                    let matrix =  Matrix.ComposeToRef(evaluated, Quaternion.FromRotationMatrix(previousMatrix.getRotationMatrix()), previousMatrix.getTranslation(), previousMatrix)    
-                    node.thinInstanceSetMatrixAt(j, matrix, true)
-                }
+              let evaluated = value instanceof Function ? value(e, node, j) : value;
+              let previousMatrix = matrices[j];
+              let previousScale = new Vector3();
+              previousMatrix.decompose(previousScale);
+              let matrix = Matrix.ComposeToRef(
+                previousScale,
+                Quaternion.FromEulerVector(evaluated),
+                previousMatrix.getTranslation(),
+                previousMatrix,
+              );
+              matrix.copyToArray(bufferMatrices, j * 16);
             });
-           //node.thinInstanceSetMatrixAt(0, node.thinInstanceGetWorldMatrices()[0], true);
-        }
-            else  console.warn(node + "is not a mesh or has no thin instances, skipping");
-    })
+            node.thinInstanceSetBuffer('matrix', bufferMatrices, 16, staticBuffer);
+          })()
+        : console.warn(node + 'has no thin instances, skipping')
+      : console.warn(node + 'Node is not a mesh, skipping');
+  });
 
-    return this;
+  return this;
 }
 
-export function thinInstanceColorFor(this: Selection, method: (d: any, n: Node, i: number) => boolean, value: Color4 | ((d: any, n: Node, i: number) => Color4)): Selection{
-
-    this.selected.forEach((node, i) => {
-        if (node instanceof Mesh && node.hasThinInstances){
-            let bufferMatrices = new Float32Array(node.thinInstanceCount * 16);
-            let matrices = node.thinInstanceGetWorldMatrices();
-            let data = node.metadata.data ??={}
-            data.forEach((e, j) => {
-                if (method(e, node, j)) {
-                    let evaluated = value instanceof Function ? value(e, node, j) : value
-                    node.thinInstanceSetAttributeAt("color", j, [evaluated.r, evaluated.g, evaluated.b, evaluated.a])
-                }
-            });
-           node.thinInstanceSetMatrixAt(0, node.thinInstanceGetWorldMatrices()[0], true);
+export function thinInstanceColor(
+  this: Selection,
+  value: Color4 | ((d: any, n: Node, i: number) => Color4),
+  staticBuffer: boolean = false,
+): Selection {
+  this.selected.forEach((node, i) => {
+    if (node instanceof Mesh && node.hasThinInstances) {
+      let colorMatrices = new Float32Array(node.thinInstanceCount * 4);
+      if (value instanceof Function) {
+        let data = (node.metadata.data ??= {});
+        data.forEach((e, j) => {
+          let evaluated = value(e, node, j);
+          colorMatrices[j * 4 + 0] = evaluated.r;
+          colorMatrices[j * 4 + 1] = evaluated.g;
+          colorMatrices[j * 4 + 2] = evaluated.b;
+          colorMatrices[j * 4 + 3] = evaluated.a;
+        });
+      } else {
+        for (let k = 0; k < node.thinInstanceCount; k++) {
+          colorMatrices[k * 4 + 0] = value.r;
+          colorMatrices[k * 4 + 1] = value.g;
+          colorMatrices[k * 4 + 2] = value.b;
+          colorMatrices[k * 4 + 3] = value.a;
         }
-            else  console.warn(node + "is not a mesh or has no thin instances, skipping");
-    })
+      }
+      node.thinInstanceSetBuffer('color', colorMatrices, 4, staticBuffer);
+    } else {
+      console.warn(node + 'Node is not a mesh or has no thin instances, skipping');
+    }
+  });
 
-    return this;
+  return this;
 }
 
+export function thinInstanceRegisterAttribute(this: Selection, attribute: string, stride: number): Selection {
+  this.selected.forEach((node, i) => {
+    node instanceof Mesh
+      ? node.hasThinInstances
+        ? node.thinInstanceRegisterAttribute(attribute, stride)
+        : console.warn(node + 'has no thin instances, skipping')
+      : console.warn(node + 'Node is not a mesh, skipping');
+  });
+
+  return this;
+}
+
+export function thinInstanceSetAttribute(
+  this: Selection,
+  attribute: string,
+  value: any | ((d: any, n: Node, i: number) => any),
+): Selection {
+  this.selected.forEach((node, i) => {
+    node instanceof Mesh
+      ? node.hasThinInstances
+        ? (node.metadata.data ??= {}).forEach((d, k) => {
+            node.thinInstanceSetAttributeAt(
+              attribute,
+              k,
+              value instanceof Function ? value((node.metadata.data ??= {}), node, i) : value,
+            );
+          })
+        : console.warn(node + 'has no thin instances, skipping')
+      : console.warn(node + 'Node is not a mesh, skipping');
+  });
+
+  return this;
+}
+
+export function thinInstanceAttributeAt(
+  this: Selection,
+  attribute: string,
+  index: number,
+  value: any | ((d: any, n: Node, i: number) => any),
+): Selection {
+  this.selected.forEach((node, i) => {
+    let evaluated = value instanceof Function ? value((node.metadata.data[index] ??= {}), node, index) : value;
+
+    node instanceof Mesh
+      ? node.hasThinInstances
+        ? node.thinInstanceSetAttributeAt(
+            attribute,
+            index,
+            value instanceof Function ? value((node.metadata.data ??= {}), node, i) : value,
+          )
+        : console.warn(node + 'has no thin instances, skipping')
+      : console.warn(node + 'Node is not a mesh, skipping');
+  });
+
+  return this;
+}
+
+export function thinInstanceMatrixAt(
+  this: Selection,
+  index: number,
+  value: Matrix | ((d: any, n: Node, i: number) => Matrix),
+): Selection {
+  this.selected.forEach((node, i) => {
+    let evaluated = value instanceof Function ? value((node.metadata.data[index] ??= {}), node, index) : value;
+    node instanceof Mesh
+      ? node.hasThinInstances
+        ? node.thinInstanceSetMatrixAt(index, evaluated)
+        : console.warn(node + 'has no thin instances, skipping')
+      : console.warn(node + 'Node is not a mesh, skipping');
+  });
+
+  return this;
+}
+
+export function thinInstancePositionAt(
+  this: Selection,
+  index: number,
+  value: Vector3 | ((d: any, n: Node, i: number) => Vector3),
+): Selection {
+  this.selected.forEach((node, i) => {
+    node instanceof Mesh
+      ? node.hasThinInstances
+        ? (() => {
+            let evaluated = value instanceof Function ? value((node.metadata.data[index] ??= {}), node, index) : value;
+            let previousMatrix = node.thinInstanceGetWorldMatrices()[index];
+            let matrix = previousMatrix.setTranslation(evaluated);
+            node.thinInstanceSetMatrixAt(index, matrix);
+          })()
+        : console.warn(node + 'has no thin instances, skipping')
+      : console.warn(node + 'Node is not a mesh, skipping');
+  });
+
+  return this;
+}
+
+export function thinInstanceScalingAt(
+  this: Selection,
+  index: number,
+  value: Vector3 | ((d: any, n: Node, i: number) => Vector3),
+): Selection {
+  this.selected.forEach((node, i) => {
+    node instanceof Mesh
+      ? node.hasThinInstances
+        ? (() => {
+            let evaluated = value instanceof Function ? value((node.metadata.data[index] ??= {}), node, index) : value;
+            let previousMatrix = node.thinInstanceGetWorldMatrices()[index];
+            let matrix = Matrix.ComposeToRef(
+              evaluated,
+              Quaternion.FromRotationMatrix(previousMatrix.getRotationMatrix()),
+              previousMatrix.getTranslation(),
+              previousMatrix,
+            );
+            node.thinInstanceSetMatrixAt(index, matrix);
+          })()
+        : console.warn(node + 'has no thin instances, skipping')
+      : console.warn(node + 'Node is not a mesh, skipping');
+  });
+
+  return this;
+}
+
+export function thinInstanceRotationAt(
+  this: Selection,
+  index: number,
+  value: Vector3 | ((d: any, n: Node, i: number) => Vector3),
+): Selection {
+  this.selected.forEach((node, i) => {
+    node instanceof Mesh
+      ? node.hasThinInstances
+        ? (() => {
+            let evaluated = value instanceof Function ? value((node.metadata.data[index] ??= {}), node, index) : value;
+            let previousMatrix = node.thinInstanceGetWorldMatrices()[index];
+            let previousScale = new Vector3();
+            previousMatrix.decompose(previousScale);
+            let matrix = Matrix.ComposeToRef(
+              previousScale,
+              Quaternion.FromEulerVector(evaluated),
+              previousMatrix.getTranslation(),
+              previousMatrix,
+            );
+            node.thinInstanceSetMatrixAt(index, matrix);
+          })()
+        : console.warn(node + 'has no thin instances, skipping')
+      : console.warn(node + 'Node is not a mesh, skipping');
+  });
+
+  return this;
+}
+
+export function thinInstanceColorAt(
+  this: Selection,
+  index: number,
+  value: Color4 | ((d: any, n: Node, i: number) => Color4),
+): Selection {
+  this.selected.forEach((node, i) => {
+    node instanceof Mesh
+      ? node.hasThinInstances
+        ? (() => {
+            let evaluated = value instanceof Function ? value((node.metadata.data[index] ??= {}), node, index) : value;
+            node.thinInstanceSetAttributeAt('color', index, [evaluated.r, evaluated.g, evaluated.b, evaluated.a]);
+          })()
+        : console.warn(node + 'has no thin instances, skipping')
+      : console.warn(node + 'Node is not a mesh, skipping');
+  });
+
+  return this;
+}
+
+export function thinInstanceMatrixFor(
+  this: Selection,
+  method: (d: any, n: Node, i: number) => boolean,
+  value: Matrix | ((d: any, n: Node, i: number) => Matrix),
+): Selection {
+  this.selected.forEach((node, i) => {
+    if (node instanceof Mesh && node.hasThinInstances) {
+      let data = (node.metadata.data ??= {});
+      data.forEach((d, k) => {
+        if (method(d, node, k)) {
+          node.thinInstanceSetMatrixAt(
+            k,
+            value instanceof Function ? value((node.metadata.data ??= {}), node, k) : value,
+            false,
+          );
+        }
+      });
+      node.thinInstanceSetMatrixAt(0, node.thinInstanceGetWorldMatrices()[0], true);
+    } else console.warn(node + 'is not a mesh or has no thin instances, skipping');
+  });
+
+  return this;
+}
+
+export function thinInstancePositionFor(
+  this: Selection,
+  method: (d: any, n: Node, i: number) => boolean,
+  value: Vector3 | ((d: any, n: Node, i: number) => Vector3),
+): Selection {
+  this.selected.forEach((node, i) => {
+    if (node instanceof Mesh && node.hasThinInstances) {
+      let bufferMatrices = new Float32Array(node.thinInstanceCount * 16);
+      let matrices = node.thinInstanceGetWorldMatrices();
+      let data = (node.metadata.data ??= {});
+      data.forEach((e, j) => {
+        if (method(e, node, j)) {
+          let evaluated = value instanceof Function ? value(e, node, j) : value;
+          let previousMatrix = node.thinInstanceGetWorldMatrices()[j];
+          let matrix = previousMatrix.setTranslation(evaluated);
+          node.thinInstanceSetMatrixAt(j, matrix, false);
+        }
+      });
+      node.thinInstanceSetMatrixAt(0, node.thinInstanceGetWorldMatrices()[0], true);
+    } else console.warn(node + 'is not a mesh or has no thin instances, skipping');
+  });
+
+  return this;
+}
+
+export function thinInstanceRotationFor(
+  this: Selection,
+  method: (d: any, n: Node, i: number) => boolean,
+  value: Vector3 | ((d: any, n: Node, i: number) => Vector3),
+): Selection {
+  this.selected.forEach((node, i) => {
+    if (node instanceof Mesh && node.hasThinInstances) {
+      let bufferMatrices = new Float32Array(node.thinInstanceCount * 16);
+      let matrices = node.thinInstanceGetWorldMatrices();
+      let data = (node.metadata.data ??= {});
+      data.forEach((e, j) => {
+        if (method(e, node, j)) {
+          let evaluated = value instanceof Function ? value(e, node, j) : value;
+          let previousMatrix = node.thinInstanceGetWorldMatrices()[j];
+          let previousScale = new Vector3();
+          previousMatrix.decompose(previousScale);
+          let matrix = Matrix.ComposeToRef(
+            previousScale,
+            Quaternion.FromEulerVector(evaluated),
+            previousMatrix.getTranslation(),
+            previousMatrix,
+          );
+          node.thinInstanceSetMatrixAt(j, matrix, false);
+        }
+      });
+      node.thinInstanceSetMatrixAt(0, node.thinInstanceGetWorldMatrices()[0], true);
+    } else console.warn(node + 'is not a mesh or has no thin instances, skipping');
+  });
+
+  return this;
+}
+
+export function thinInstanceScalingFor(
+  this: Selection,
+  method: (d: any, n: Node, i: number) => boolean,
+  value: Vector3 | ((d: any, n: Node, i: number) => Vector3),
+): Selection {
+  this.selected.forEach((node, i) => {
+    if (node instanceof Mesh && node.hasThinInstances) {
+      let bufferMatrices = new Float32Array(node.thinInstanceCount * 16);
+      let matrices = node.thinInstanceGetWorldMatrices();
+      let data = (node.metadata.data ??= {});
+      data.forEach((e, j) => {
+        if (method(e, node, j)) {
+          let evaluated = value instanceof Function ? value(e, node, j) : value;
+          let previousMatrix = node.thinInstanceGetWorldMatrices()[j];
+          let matrix = Matrix.ComposeToRef(
+            evaluated,
+            Quaternion.FromRotationMatrix(previousMatrix.getRotationMatrix()),
+            previousMatrix.getTranslation(),
+            previousMatrix,
+          );
+          node.thinInstanceSetMatrixAt(j, matrix, true);
+        }
+      });
+      //node.thinInstanceSetMatrixAt(0, node.thinInstanceGetWorldMatrices()[0], true);
+    } else console.warn(node + 'is not a mesh or has no thin instances, skipping');
+  });
+
+  return this;
+}
+
+export function thinInstanceColorFor(
+  this: Selection,
+  method: (d: any, n: Node, i: number) => boolean,
+  value: Color4 | ((d: any, n: Node, i: number) => Color4),
+): Selection {
+  this.selected.forEach((node, i) => {
+    if (node instanceof Mesh && node.hasThinInstances) {
+      let bufferMatrices = new Float32Array(node.thinInstanceCount * 16);
+      let matrices = node.thinInstanceGetWorldMatrices();
+      let data = (node.metadata.data ??= {});
+      data.forEach((e, j) => {
+        if (method(e, node, j)) {
+          let evaluated = value instanceof Function ? value(e, node, j) : value;
+          node.thinInstanceSetAttributeAt('color', j, [evaluated.r, evaluated.g, evaluated.b, evaluated.a]);
+        }
+      });
+      node.thinInstanceSetMatrixAt(0, node.thinInstanceGetWorldMatrices()[0], true);
+    } else console.warn(node + 'is not a mesh or has no thin instances, skipping');
+  });
+
+  return this;
+}

--- a/src/selection/utility/boundingBox.ts
+++ b/src/selection/utility/boundingBox.ts
@@ -9,27 +9,35 @@ import { Selection } from '../index';
  *
  * @returns instance of BoundingInfo class, an object containing all bounding box values.
  */
-export function boundingBox(this: Selection, exclude: string = ""): BoundingInfo {
+export function boundingBox(this: Selection, exclude: string = ''): BoundingInfo {
   let firstNode = this.selected[0];
-  let selectionMin: Vector3 = (firstNode instanceof Mesh) ? firstNode.getBoundingInfo().boundingBox.minimumWorld : (firstNode instanceof TransformNode) ? (this.selected[0] as TransformNode).position : new Vector3;
-  let selectionMax: Vector3 = (firstNode instanceof Mesh) ? firstNode.getBoundingInfo().boundingBox.maximumWorld : (firstNode instanceof TransformNode) ? (this.selected[0] as TransformNode).position : new Vector3;
-
+  let selectionMin: Vector3 =
+    firstNode instanceof Mesh
+      ? firstNode.getBoundingInfo().boundingBox.minimumWorld
+      : firstNode instanceof TransformNode
+      ? (this.selected[0] as TransformNode).position
+      : new Vector3();
+  let selectionMax: Vector3 =
+    firstNode instanceof Mesh
+      ? firstNode.getBoundingInfo().boundingBox.maximumWorld
+      : firstNode instanceof TransformNode
+      ? (this.selected[0] as TransformNode).position
+      : new Vector3();
 
   this.selected.forEach((node, i) => {
     node.computeWorldMatrix(true);
-    let meshes = (node.getChildMeshes().length > 0) ? node.getChildMeshes() : [node];
+    let meshes = node.getChildMeshes().length > 0 ? node.getChildMeshes() : [node];
     meshes.forEach((mesh, j) => {
       mesh.computeWorldMatrix(true); //without this the bounding box is calculated at the mesh creation position...TODO investigate.
-      if (mesh instanceof Mesh && !Tags.MatchesQuery((Tags.HasTags(mesh)) ? Tags.GetTags(mesh) : '', exclude)) {
-      let nodeMin = mesh.getBoundingInfo().boundingBox.minimumWorld;
-      let nodeMax = mesh.getBoundingInfo().boundingBox.maximumWorld;
-      selectionMin = Vector3.Minimize(selectionMin, nodeMin);
-      selectionMax = Vector3.Maximize(selectionMax, nodeMax);
+      if (mesh instanceof Mesh && !Tags.MatchesQuery(Tags.HasTags(mesh) ? Tags.GetTags(mesh) : '', exclude)) {
+        let nodeMin = mesh.getBoundingInfo().boundingBox.minimumWorld;
+        let nodeMax = mesh.getBoundingInfo().boundingBox.maximumWorld;
+        selectionMin = Vector3.Minimize(selectionMin, nodeMin);
+        selectionMax = Vector3.Maximize(selectionMax, nodeMax);
       } else {
         selectionMin = Vector3.Minimize(selectionMin, (mesh as TransformNode).position);
         selectionMax = Vector3.Maximize(selectionMax, (mesh as TransformNode).position);
       }
-    
     });
   });
 

--- a/src/selection/utility/filter.ts
+++ b/src/selection/utility/filter.ts
@@ -13,7 +13,7 @@ import { Selection } from '../index';
 export function filter(this: Selection, method: (d: any, n: Node, i: number) => boolean) {
   let filtered: Node[] = [];
   this.selected.forEach((node, i) => {
-    if (method(node.metadata.data ??= {}, node, i)) filtered.push(node);
+    if (method((node.metadata.data ??= {}), node, i)) filtered.push(node);
   });
 
   return new Selection(filtered, this.scene);

--- a/src/selection/utility/run.ts
+++ b/src/selection/utility/run.ts
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright : J.P. Morgan Chase & Co.
 
-import { Mesh, Node} from '@babylonjs/core';
+import { Mesh, Node } from '@babylonjs/core';
 import { Selection } from '../index';
 
 export function run(this: Selection, method: (d: any, node: Node, i: number) => any) {
   let values: Object[] = [];
   this.selected.forEach((node, i) => {
-    method(node.metadata.data ??= {}, node, i)
+    method((node.metadata.data ??= {}), node, i);
   });
   return this;
 }

--- a/src/selection/utility/select.ts
+++ b/src/selection/utility/select.ts
@@ -19,14 +19,16 @@ export function select(this: Selection, name: string): Selection {
   let selected: any = [];
 
   if (indicator === '.') {
-      this.selected.forEach((element) => (selected = selected.concat(element?.getChildren((node) => node.name == text))));
-      return new Selection(selected, this.scene);
+    this.selected.forEach((element) => (selected = selected.concat(element?.getChildren((node) => node.name == text))));
+    return new Selection(selected, this.scene);
   } else if (indicator === '#') {
-      this.selected.forEach((element) => (selected = selected.concat(element?.getChildren((node) => node.id == text))));
-      return new Selection(selected, this.scene);
+    this.selected.forEach((element) => (selected = selected.concat(element?.getChildren((node) => node.id == text))));
+    return new Selection(selected, this.scene);
   } else if (indicator === '$') {
-      this.selected.forEach((element) => (selected = selected.concat(element?.getChildren((node) => Tags.MatchesQuery(node, text) == true))));
-      return new Selection(selected, this.scene);
+    this.selected.forEach(
+      (element) => (selected = selected.concat(element?.getChildren((node) => Tags.MatchesQuery(node, text) == true))),
+    );
+    return new Selection(selected, this.scene);
   }
 
   return new Selection([], this.scene);
@@ -41,8 +43,14 @@ export function select(this: Selection, name: string): Selection {
 export function selectName(this: Selection, name: string | string[]): Selection {
   let selected: Node[] = [];
   Array.isArray(name)
-    ? name.forEach((e, i) => (this.selected.forEach((element) => (selected = selected.concat(element?.getChildren((node) => node.name == e))))))
-    : (this.selected.forEach((element) => (selected = selected.concat(element?.getChildren((node) => node.name == name)))));
+    ? name.forEach((e, i) =>
+        this.selected.forEach(
+          (element) => (selected = selected.concat(element?.getChildren((node) => node.name == e))),
+        ),
+      )
+    : this.selected.forEach(
+        (element) => (selected = selected.concat(element?.getChildren((node) => node.name == name))),
+      );
   return new Selection(selected, this.scene);
 }
 
@@ -55,8 +63,10 @@ export function selectName(this: Selection, name: string | string[]): Selection 
 export function selectId(this: Selection, id: string | string[]): Selection {
   let selected: Node[] = [];
   Array.isArray(id)
-    ? id.forEach((e, i) => (this.selected.forEach((element) => (selected = selected.concat(element?.getChildren((node) => node.id == e))))))
-    : (this.selected.forEach((element) => (selected = selected.concat(element?.getChildren((node) => node.id == id)))));
+    ? id.forEach((e, i) =>
+        this.selected.forEach((element) => (selected = selected.concat(element?.getChildren((node) => node.id == e)))),
+      )
+    : this.selected.forEach((element) => (selected = selected.concat(element?.getChildren((node) => node.id == id))));
   return new Selection(selected, this.scene);
 }
 
@@ -69,8 +79,14 @@ export function selectId(this: Selection, id: string | string[]): Selection {
 export function selectTag(this: Selection, tag: string | string[]): Selection {
   let selected: Node[] = [];
   Array.isArray(tag)
-    ? tag.forEach((e, i) => (this.selected.forEach((element) => (selected = selected.concat(element?.getChildren((node) => Tags.MatchesQuery(node, e) == true))))))
-    : (this.selected.forEach((element) => (selected = selected.concat(element?.getChildren((node) => Tags.MatchesQuery(node, tag) == true)))));
+    ? tag.forEach((e, i) =>
+        this.selected.forEach(
+          (element) => (selected = selected.concat(element?.getChildren((node) => Tags.MatchesQuery(node, e) == true))),
+        ),
+      )
+    : this.selected.forEach(
+        (element) => (selected = selected.concat(element?.getChildren((node) => Tags.MatchesQuery(node, tag) == true))),
+      );
   return new Selection(selected, this.scene);
 }
 
@@ -88,19 +104,19 @@ export function selectData(
 ): Selection {
   let selected: Node[] = [];
   Array.isArray(key) && Array.isArray(value)
-    ? key.forEach(
-        (e, i) =>
-          (this.selected.forEach((element) => selected = [
-            ...selected,
-            ...element.getChildren()
-          ].filter((node) => node.metadata != null)
-          .filter((node) => node.metadata.data[e] == value[i]),
-          )),
+    ? key.forEach((e, i) =>
+        this.selected.forEach(
+          (element) =>
+            (selected = [...selected, ...element.getChildren()]
+              .filter((node) => node.metadata != null)
+              .filter((node) => node.metadata.data[e] == value[i])),
+        ),
       )
-    : (this.selected.forEach((element) => selected = [
-      ...selected,
-      ...element.getChildren()
-    ].filter((node) => node.metadata != null)
-    .filter((node) => node.metadata.data[key as string] == value),));
+    : this.selected.forEach(
+        (element) =>
+          (selected = [...selected, ...element.getChildren()]
+            .filter((node) => node.metadata != null)
+            .filter((node) => node.metadata.data[key as string] == value)),
+      );
   return new Selection(selected, this.scene);
 }


### PR DESCRIPTION
**Added D3 style transitions**
Added the transition() method to selections which initiates a new or adds to an existing transition selection. The following transform method calls (ie scale, position, rotation) will be animated according the the transition options. Chaining transition() calls can be used to sequence animation one after the other or to change the options of transitions playing concurrently. Also added the tween() method which allows for more complex animations of objects. 

