### PR TITLE
fixed issue with props when using translate + warn

### DIFF
--- a/anu-examples/examples/Animation/animate.js
+++ b/anu-examples/examples/Animation/animate.js
@@ -10,7 +10,6 @@ export const animate = function(engine){
     
   const scene = new Scene(engine)
 
-  console.log(scene.getEngine().constructor.LastCreatedScene)
 
   new HemisphericLight('light1', new Vector3(0, 10, 0), scene)
 
@@ -20,30 +19,39 @@ export const animate = function(engine){
   //let box = anu.create('box', 'ourBox', {}, [{}]);
 
 
-  let nodes = anu.bind("box", [...new Array(1)])
+  let nodes = anu.bind("box", {}, [...new Array(10)])
 
   //let boxSelection = new anu.Selection(nodes.selected, scene, new Animatable(scene, box))
 
 
-  nodes
-    .material(() => new StandardMaterial('mat'))
-    .transition((d,n,i) => ({duration: 1000, loopMode: 0, delay: 0,  easingFunction: new CircleEase(), onAnimationEnd: () =>  { console.log('hi') } }))
-    .positionX(2)
-    .transition({duration: 1000, loopMode: 0, delay: 0,  easingFunction: new CircleEase(), onAnimationEnd: () =>  { console.log('hi') } })
-    .positionX(-2)
-    .transition({duration: 1000, loopMode: 0, delay: 0,  easingFunction: new CircleEase()})
-    .positionX(2)
-    .positionY(2)
-    .transition({duration: 1000, loopMode: 0, delay: 0,  easingFunction: new CircleEase()})
-    .tween((d,n,i) => { 
-      let inter = interpolateBrBG
+  // nodes
+  //   .material(() => new StandardMaterial('mat'))
+  //   .transition((d,n,i) => ({duration: 1000, loopMode: 0, delay: 0,  easingFunction: new CircleEase(), onAnimationEnd: () =>  { console.log('hi') } }))
+  //   .positionX(2)
+  //   .transition({duration: 1000, loopMode: 0, delay: 0,  easingFunction: new CircleEase(), onAnimationEnd: () =>  { console.log('hi') } })
+  //   .positionX(-2)
+  //   .transition({duration: 1000, loopMode: 0, delay: 0,  easingFunction: new CircleEase()})
+  //   .positionX(2)
+  //   .positionY(2)
+  //   .transition({duration: 1000, loopMode: 0, delay: 0,  easingFunction: new CircleEase()})
+  //   .tween((d,n,i) => { 
+  //     let inter = interpolateBrBG
 
-      return (t) => {
-        let rgb = color(inter(t)).rgb();
-        n.material.diffuseColor = new Color3(rgb.r / 255, rgb.g /255, rgb.b /255);
-      }
+  //     return (t) => {
+  //       let rgb = color(inter(t)).rgb();
+  //       n.material.diffuseColor = new Color3(rgb.r / 255, rgb.g /255, rgb.b /255);
+  //     }
       
+  //   })
+
+    nodes.transition().props({'position.x': ()=> {
+      console.log("position")
+      return 2;
+    },
+    'scaling.y': 2
     })
+
+
 
   return scene;
 }; 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jpmorganchase/anu",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "",
   "type": "module",
   "files": [

--- a/src/selection/property/prop.ts
+++ b/src/selection/property/prop.ts
@@ -6,7 +6,7 @@ import { Selection } from '../index';
 import set from 'lodash-es/set';
 import get from 'lodash-es/get';
 import hasIn from 'lodash-es/hasIn';
-import { createTransition } from '../animation/transition';
+import { createTransition, createTransitions } from '../animation/transition';
 
 /**
  * Called from a selection this method allows you to set any property or subproperty of nodes in the selection given that property exists.
@@ -55,11 +55,13 @@ export function prop(this: Selection, accessor: string, value: any) {
  * @returns The modified selection
  */
 export function props(this: Selection, properties: {}) {
+  
+  if (this.transitions.length > 0) {
+    console.log("transition")
+    createTransitions(this, properties);
+  } else {
   this.selected.forEach((node, i) => {
     for (let accessor in properties) {
-      if (this.transitions.length > 0) {
-        createTransition(this, accessor, properties[accessor]);
-      } else {
         hasIn(node, accessor)
           ? set(
               node,
@@ -68,10 +70,10 @@ export function props(this: Selection, properties: {}) {
                 ? (properties as any)[accessor]((node.metadata.data ??= {}), node, i)
                 : (properties as any)[accessor],
             )
-          : console.log(accessor + ' not property of ' + node);
+          : console.warn(accessor + ' not property of ' + node);
       }
-    }
-  });
+    });
+  }
 
   return this;
 }


### PR DESCRIPTION
When using transition props would loop through the list of nodes n2 times, this has been fixed by creating the createAnimations method which handles the full loop of nodes and properties now. Console.Warn messages have also been added to prop and props when using transitions for trying to change a property that doesn't exist on the node. 