### PR TITLE
added control options for transitions

### DIFF
--- a/anu-examples/examples/Animation/animate.js
+++ b/anu-examples/examples/Animation/animate.js
@@ -19,37 +19,48 @@ export const animate = function(engine){
   //let box = anu.create('box', 'ourBox', {}, [{}]);
 
 
-  let nodes = anu.bind("box", {}, [...new Array(10)])
+  let nodes = anu.bind("box", {}, [...new Array(5000)])
 
   //let boxSelection = new anu.Selection(nodes.selected, scene, new Animatable(scene, box))
 
 
-  // nodes
-  //   .material(() => new StandardMaterial('mat'))
-  //   .transition((d,n,i) => ({duration: 1000, loopMode: 0, delay: 0,  easingFunction: new CircleEase(), onAnimationEnd: () =>  { console.log('hi') } }))
-  //   .positionX(2)
-  //   .transition({duration: 1000, loopMode: 0, delay: 0,  easingFunction: new CircleEase(), onAnimationEnd: () =>  { console.log('hi') } })
-  //   .positionX(-2)
-  //   .transition({duration: 1000, loopMode: 0, delay: 0,  easingFunction: new CircleEase()})
-  //   .positionX(2)
-  //   .positionY(2)
-  //   .transition({duration: 1000, loopMode: 0, delay: 0,  easingFunction: new CircleEase()})
-  //   .tween((d,n,i) => { 
-  //     let inter = interpolateBrBG
-
-  //     return (t) => {
-  //       let rgb = color(inter(t)).rgb();
-  //       n.material.diffuseColor = new Color3(rgb.r / 255, rgb.g /255, rgb.b /255);
-  //     }
-      
-  //   })
-
-    nodes.transition().props({'position.x': ()=> {
-      console.log("position")
-      return 2;
-    },
-    'scaling.y': 2
+  let transitions = nodes
+    .material(() => new StandardMaterial())
+    .transition({duration: 1000})
+    .tween((d,n,i) => { 
+      let inter = interpolateBrBG
+      return (t) => {
+        let rgb = color(inter(t)).rgb();
+        n.material.diffuseColor = new Color3(rgb.r / 255, rgb.g /255, rgb.b /255);
+      }
     })
+    .transition()
+    .tween((d,n,i) => { 
+      let inter = interpolate(0,2)
+      return (t) => {
+        n.position.x = inter(t)  
+      }
+    })
+
+    // let transitions = nodes.transition({duration: 1000, delay: 500}).props({'position.x': ()=> {
+    //   console.log("position")
+    //   return 2;
+    // }}).transition().props({"position.x": 1})
+
+    // let transitions = nodes.transition({duration: 1000}).positionX(2).positionY(2)
+    //                        .transition({duration: 1000}).positionX(0).positionY(0)
+    //                        .transition({duration: 1000}).positionX(1).positionY(1)
+                            
+                            
+      //transitions.stopTransitions();
+
+    // setTimeout(() => {
+    //   transitions.stopTweens()
+    // }, 1500)
+
+    //    setTimeout(() => {
+    //   transitions.restartTransitions()
+    // }, 1000)
 
 
 

--- a/docs/guide/deeper_topics/transitions.md
+++ b/docs/guide/deeper_topics/transitions.md
@@ -138,3 +138,36 @@ scene.onPointerDown = (pointer) => {
 <inlineView scene="Line_Tween" />
 
 </multiView>
+
+# Controlling Active Transitions  
+
+There are several methods you can call on selections with active transitions to stop, end, pause etc... These methods are helpful when you need to interrupt animations in progress to start a different set of transitions. For example when the user clicks a animate button multiple times. 
+
+| Method Name            | Description                                                                                     |
+|------------------------|-------------------------------------------------------------------------------------------------|
+| `stopTweens`           | Stops all tween `onBeforeRenderObservables` currently running or waiting to be run on the selection. |
+| `stopTransitions`      | Stops all animations currently playing or waiting to be played on the selection.                |
+| `resetTransitions`     | Resets and plays all animations currently playing or waiting to be played on the selection.     |
+| `resetStopTransitions` | Resets and stops all animations currently playing or waiting to be played on the selection.     |
+| `pauseTransitions`     | Pauses all animations currently playing or waiting to be played on the selection.               |
+| `restartTransitions`   | Resumes all paused animations currently playing or waiting to be played on the selection.       |
+| `endTransitions`       | Skips to the end of all animations currently playing or waiting to be played on the selection.  |
+
+
+
+```js
+let box = anu.bind('box', {}, [...Array(10).keys()]);
+
+let transitionOptions = {
+  duration: 500,
+  delay: 100,
+  easingFunction: new CircleEase(),
+  onAnimationEnd: () => console.log('animate')
+}
+
+var box_transition = box.transition(transitionOptions).position(() => Vector3.Random(-5,5))
+
+setTimeout(() => {
+  box_transition.stopTransitions();
+}, 250)
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jpmorganchase/anu",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "",
   "type": "module",
   "files": [

--- a/src/selection/index.ts
+++ b/src/selection/index.ts
@@ -52,7 +52,7 @@ import {
   thinInstanceRotationFor,
   thinInstanceColorFor,
 } from './property/thin';
-import { transition, Transition, tween } from './animation/transition';
+import { transition, Transition, tween, stopTransitions, resetTransitions, restartTransitions, endTransitions, resetStopTransitions, pauseTransitions, stopTweens} from './animation/transition';
 
 /*
     The core class of anujs. All functions should return 
@@ -148,4 +148,14 @@ export class Selection {
   public bindThinInstance = bindThinInstance;
   public transition = transition;
   public tween = tween;
+  public stopTransitions = stopTransitions;
+  public resetTransitions = resetTransitions;
+  public resetStopTransitions = resetStopTransitions;
+  public pauseTransitions = pauseTransitions;
+  public restartTransitions = restartTransitions;
+  public endTransitions = endTransitions;
+  public stopTweens = stopTweens;
+
+
+
 }


### PR DESCRIPTION
Added the following methods 

| Method Name            | Description                                                                                     |
|------------------------|-------------------------------------------------------------------------------------------------|
| `stopTweens`           | Stops all tween `onBeforeRenderObservables` currently running or waiting to be run on the selection. |
| `stopTransitions`      | Stops all animations currently playing or waiting to be played on the selection.                |
| `resetTransitions`     | Resets and plays all animations currently playing or waiting to be played on the selection.     |
| `resetStopTransitions` | Resets and stops all animations currently playing or waiting to be played on the selection.     |
| `pauseTransitions`     | Pauses all animations currently playing or waiting to be played on the selection.               |
| `restartTransitions`   | Resumes all paused animations currently playing or waiting to be played on the selection.       |
| `endTransitions`       | Skips to the end of all animations currently playing or waiting to be played on the selection.  |

